### PR TITLE
feat: breadcrumb 추가

### DIFF
--- a/frontend/sellution-app/src/client/component/customer/ListComponent.jsx
+++ b/frontend/sellution-app/src/client/component/customer/ListComponent.jsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom';
 
 const ListComponent = () => {
   return (
-    <div>
+    <div className='bg-red-600 w-full h-full'>
       <div className='text-lg'>회원 목록 화면</div>
       <Link to='/customer/detail' className='w-fit h-5 bg-blue-400'>
         회원 상세 이동 테스트

--- a/frontend/sellution-app/src/client/layout/BasicLayout.jsx
+++ b/frontend/sellution-app/src/client/layout/BasicLayout.jsx
@@ -4,15 +4,15 @@ import { Outlet } from 'react-router-dom';
 
 const BasicLayout = () => {
   return (
-    <div className='w-dvw h-dvh flex flex-col'>
-      <div className='w-[100%] h-[64px]'>
+    <div className='w-dvw h-dvh flex flex-col overflow-hidden'>
+      <div className='w-full h-16'>
         <NavbarComponent />
       </div>
       <div className='w-full flex flex-auto'>
         <div className='w-0 lg:w-[250px] flex-shrink-0'>
           <SidebarCompoent />
         </div>
-        <main className='flex-auto bg-green-50'>
+        <main className='h-full p-5 flex-auto bg-green-50'>
           <Outlet />
         </main>
       </div>

--- a/frontend/sellution-app/src/client/layout/MainHeaderNavLayout.jsx
+++ b/frontend/sellution-app/src/client/layout/MainHeaderNavLayout.jsx
@@ -1,20 +1,20 @@
 import { NavLink, Outlet } from 'react-router-dom';
 
-const MainHeaderNavLayout = (props) => {
+const MainHeaderNavLayout = ({ navMenus }) => {
   return (
     <>
       <nav>
-        {props.nav.map(([path, label], index) => (
+        {navMenus.map((navMenu, index) => (
           <NavLink
             key={index}
-            to={`${path}`} // 절대 경로로 설정
+            to={`${navMenu.link}`} // 절대 경로로 설정
             className={({ isActive }) =>
               isActive
                 ? 'text-brandOrange bg-brandOrange-light'
                 : 'text-gray-500 hover:text-gray-800 hover:bg-gray-100'
             }
           >
-            {label}
+            {navMenu.label}
           </NavLink>
         ))}
       </nav>

--- a/frontend/sellution-app/src/client/layout/partials/MainHeaderComponent.jsx
+++ b/frontend/sellution-app/src/client/layout/partials/MainHeaderComponent.jsx
@@ -1,10 +1,29 @@
-const MainHeaderComponent = ({ children }) => {
+import { Link } from 'react-router-dom';
+
+const MainHeaderComponent = ({ breadcrumbs, children }) => {
   return (
-    <div>
-      <div>경로</div>
-      <div>경로 제목</div>
-      {children}
-    </div>
+    <section className='box-content w-full h-full flex flex-col bg-blue-50'>
+      <div className='h-16'>
+        <div className='text-sm'>
+          <ul className='flex space-x-2'>
+            {breadcrumbs.map((breadcrumb, index) => (
+              <li key={index} className='flex items-center'>
+                {index > 0 && <span className='mx-2'>/</span>}
+                {breadcrumb.link ? (
+                  <Link to={breadcrumb.link} className='text-gray-500 hover:text-gray-700'>
+                    {breadcrumb.label}
+                  </Link>
+                ) : (
+                  <span className='text-gray-900'>{breadcrumb.label}</span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div>경로 제목</div>
+      </div>
+      <div className='w-full flex-auto'>{children}</div>
+    </section>
   );
 };
 

--- a/frontend/sellution-app/src/client/layout/partials/NavbarComponent.jsx
+++ b/frontend/sellution-app/src/client/layout/partials/NavbarComponent.jsx
@@ -2,8 +2,8 @@ import { Link } from 'react-router-dom';
 
 const NavbarComponent = () => {
   return (
-    <nav className='w-full h-full bg-navbarBackground'>
-      <div className='px-3 py-3 lg:px-5'>
+    <nav className='w-full h-full bg-navbarBackground flex justify-between items-center'>
+      <div className='flex-1 px-3 py-3 lg:px-5'>
         <div className='flex justify-between items-center'>
           <div className='flex items-center justify-start'>
             <button
@@ -94,7 +94,7 @@ const NavbarComponent = () => {
                 </g>
               </svg>
             </button>
-            <button className='w-[150px] h-9 text-white bg-gray-500 hover:bg-gray-400 focus:ring-2 focus:ring-gray-200 rounded-lg text-xs items-center'>
+            <button className='w-[150px] h-9 text-xs mr-3 lg:mr-1 text-white bg-gray-500 hover:bg-gray-400 focus:ring-2 focus:ring-gray-200 rounded-lg'>
               테스트 관리자
             </button>
           </div>

--- a/frontend/sellution-app/src/client/router/customer/customerRouter.jsx
+++ b/frontend/sellution-app/src/client/router/customer/customerRouter.jsx
@@ -23,7 +23,7 @@ const customerRouter = () => {
     {
       path: 'list',
       element: (
-        <MainHeaderComponent>
+        <MainHeaderComponent breadcrumbs={[{ label: '홈', link: '/home' }, { label: '회원 관리' }]}>
           <LazyComponent Component={ListPage} />
         </MainHeaderComponent>
       ),
@@ -31,7 +31,13 @@ const customerRouter = () => {
     {
       path: 'add',
       element: (
-        <MainHeaderComponent>
+        <MainHeaderComponent
+          breadcrumbs={[
+            { label: '홈', link: '/home' },
+            { label: '회원 관리', link: '/customer' },
+            { label: '회원 등록' },
+          ]}
+        >
           <LazyComponent Component={AddPage} />
         </MainHeaderComponent>
       ),
@@ -39,13 +45,19 @@ const customerRouter = () => {
     {
       path: 'detail',
       element: (
-        <MainHeaderComponent>
+        <MainHeaderComponent
+          breadcrumbs={[
+            { label: '홈', link: '/home' },
+            { label: '회원 관리', link: '/customer' },
+            { label: '회원 상세' },
+          ]}
+        >
           <MainHeaderNavLayout
-            nav={[
-              ['default', '기본 정보'],
-              ['payment', '결제 정보'],
-              ['address', '배송지 정보'],
-              ['order', '주문 정보'],
+            navMenus={[
+              { label: '기본 정보', link: 'default' },
+              { label: '결제 정보', link: 'payment' },
+              { label: '배송지 정보', link: 'address' },
+              { label: '주문 정보', link: 'order' },
             ]}
           />
         </MainHeaderComponent>

--- a/frontend/sellution-app/src/client/router/event/eventRouter.jsx
+++ b/frontend/sellution-app/src/client/router/event/eventRouter.jsx
@@ -16,7 +16,9 @@ const eventRouter = () => {
     {
       path: 'list',
       element: (
-        <MainHeaderComponent>
+        <MainHeaderComponent
+          breadcrumbs={[{ label: '홈', link: '/home' }, { label: '이벤트 관리' }]}
+        >
           <LazyComponent Component={ListPage} />
         </MainHeaderComponent>
       ),

--- a/frontend/sellution-app/src/client/router/order/orderRouter.jsx
+++ b/frontend/sellution-app/src/client/router/order/orderRouter.jsx
@@ -17,7 +17,7 @@ const orderRouter = () => {
     {
       path: 'list',
       element: (
-        <MainHeaderComponent>
+        <MainHeaderComponent breadcrumbs={[{ label: '홈', link: '/home' }, { label: '주문 관리' }]}>
           <LazyComponent Component={ListPage} />
         </MainHeaderComponent>
       ),
@@ -25,7 +25,13 @@ const orderRouter = () => {
     {
       path: 'detail',
       element: (
-        <MainHeaderComponent>
+        <MainHeaderComponent
+          breadcrumbs={[
+            { label: '홈', link: '/home' },
+            { label: '주문 관리', link: '/order' },
+            { label: '주문 상세' },
+          ]}
+        >
           <LazyComponent Component={DetailPage} />
         </MainHeaderComponent>
       ),

--- a/frontend/sellution-app/src/client/router/paymentHistory/paymentHistoryRouter.jsx
+++ b/frontend/sellution-app/src/client/router/paymentHistory/paymentHistoryRouter.jsx
@@ -17,7 +17,9 @@ const paymentHistoryRouter = () => {
     {
       path: 'list',
       element: (
-        <MainHeaderComponent>
+        <MainHeaderComponent
+          breadcrumbs={[{ label: '홈', link: '/home' }, { label: '결제 내역 관리' }]}
+        >
           <LazyComponent Component={ListPage} />
         </MainHeaderComponent>
       ),
@@ -25,7 +27,13 @@ const paymentHistoryRouter = () => {
     {
       path: 'detail',
       element: (
-        <MainHeaderComponent>
+        <MainHeaderComponent
+          breadcrumbs={[
+            { label: '홈', link: '/home' },
+            { label: '결제 내역 관리', link: '/payment-history' },
+            { label: '결제 내역 상세' },
+          ]}
+        >
           <LazyComponent Component={DetailPage} />
         </MainHeaderComponent>
       ),

--- a/frontend/sellution-app/src/client/router/product/productRouter.jsx
+++ b/frontend/sellution-app/src/client/router/product/productRouter.jsx
@@ -23,11 +23,11 @@ const productRouter = () => {
     {
       path: '',
       element: (
-        <MainHeaderComponent>
+        <MainHeaderComponent breadcrumbs={[{ label: '홈', link: '/home' }, { label: '상품 관리' }]}>
           <MainHeaderNavLayout
-            nav={[
-              ['list', '상품 목록'],
-              ['category-list', '카테고리 목록'],
+            navMenus={[
+              { label: '상품 목록', link: 'list' },
+              { label: '카테고리 목록', link: 'category-list' },
             ]}
           />
         </MainHeaderComponent>
@@ -46,7 +46,13 @@ const productRouter = () => {
     {
       path: 'detail',
       element: (
-        <MainHeaderComponent>
+        <MainHeaderComponent
+          breadcrumbs={[
+            { label: '홈', link: '/home' },
+            { label: '상품 관리', link: '/product' },
+            { label: '상품 상세' },
+          ]}
+        >
           <LazyComponent Component={DetailPage} />
         </MainHeaderComponent>
       ),
@@ -54,7 +60,13 @@ const productRouter = () => {
     {
       path: 'add',
       element: (
-        <MainHeaderComponent>
+        <MainHeaderComponent
+          breadcrumbs={[
+            { label: '홈', link: '/home' },
+            { label: '상품 관리', link: '/product' },
+            { label: '상품 등록' },
+          ]}
+        >
           <LazyComponent Component={AddPage} />
         </MainHeaderComponent>
       ),
@@ -62,7 +74,13 @@ const productRouter = () => {
     {
       path: 'category-detail',
       element: (
-        <MainHeaderComponent>
+        <MainHeaderComponent
+          breadcrumbs={[
+            { label: '홈', link: '/home' },
+            { label: '상품 관리', link: '/product' },
+            { label: '카테고리 상세' },
+          ]}
+        >
           <LazyComponent Component={CategoryDetailPage} />
         </MainHeaderComponent>
       ),
@@ -70,7 +88,13 @@ const productRouter = () => {
     {
       path: 'category-add',
       element: (
-        <MainHeaderComponent>
+        <MainHeaderComponent
+          breadcrumbs={[
+            { label: '홈', link: '/home' },
+            { label: '상품 관리', link: '/product' },
+            { label: '카테고리 등록' },
+          ]}
+        >
           <LazyComponent Component={CategoryAddPage} />
         </MainHeaderComponent>
       ),

--- a/frontend/sellution-app/src/client/router/shopManagement/shopManagementRouter.jsx
+++ b/frontend/sellution-app/src/client/router/shopManagement/shopManagementRouter.jsx
@@ -15,12 +15,14 @@ const shopManagementRouter = () => {
     {
       path: '',
       element: (
-        <MainHeaderComponent>
+        <MainHeaderComponent
+          breadcrumbs={[{ label: '홈', link: '/home' }, { label: '쇼핑몰 관리' }]}
+        >
           <MainHeaderNavLayout
-            nav={[
-              ['url-setting', 'URL 설정'],
-              ['display-setting', '화면 설정'],
-              ['sale-setting', '판매 설정'],
+            navMenus={[
+              { label: 'URL 설정', link: 'url-setting' },
+              { label: '화면 설정', link: 'display-setting' },
+              { label: '판매 설정', link: 'sale-setting' },
             ]}
           />
         </MainHeaderComponent>


### PR DESCRIPTION
## :: 작업 내용
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
- [ ] 테스트

## :: 구현 목표
- 사용자의 이동 경로를 나타내는 breadcrumb 구현

## :: 구현 사항 설명
- 이동 경로를 표현하기 위해 label과 link를 키로 갖는 객체를 요소로 갖는 리스트를 공통 컴포넌트에 props로 전달
- 공통 컴포넌트 내에서 전달받은 breadcrumbs를 map을 이용해서 배열을 렌더링
- 배열 렌더링 시 이전 경로로 이동할 수 있게 Link 태그를  사용

## :: 특이 사항
-  UI 수정 예정
-  회원 부분의 경우, 회원 상세에서 결제 수단, 배송지, 주문 등을 볼 수 있는데, 이 경우 네비게이션 바가 있기에 breadcrumb는 회원 상세까지만 구현

### :: 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
#