### PR TITLE
[K1P-214] feat: 회원 로그인 api 연결 및 사업체 정보 조회 api 연결

### DIFF
--- a/backend/server/src/main/java/shop/sellution/server/company/application/CompanyService.java
+++ b/backend/server/src/main/java/shop/sellution/server/company/application/CompanyService.java
@@ -1,0 +1,7 @@
+package shop.sellution.server.company.application;
+
+import shop.sellution.server.company.dto.FindCompanyInfoRes;
+
+public interface CompanyService {
+    FindCompanyInfoRes findCompanyId(String companyName);
+}

--- a/backend/server/src/main/java/shop/sellution/server/company/application/CompanyServiceImpl.java
+++ b/backend/server/src/main/java/shop/sellution/server/company/application/CompanyServiceImpl.java
@@ -1,0 +1,33 @@
+package shop.sellution.server.company.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shop.sellution.server.company.domain.Company;
+import shop.sellution.server.company.domain.CompanyImage;
+import shop.sellution.server.company.domain.repository.CompanyImageRepository;
+import shop.sellution.server.company.domain.repository.CompanyRepository;
+import shop.sellution.server.company.dto.FindCompanyInfoRes;
+import shop.sellution.server.global.exception.BadRequestException;
+
+import java.util.List;
+
+import static shop.sellution.server.global.exception.ExceptionCode.NOT_FOUND_COMPANY;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CompanyServiceImpl implements CompanyService {
+
+    private final CompanyRepository companyRepository;
+    private final CompanyImageRepository companyImageRepository;
+
+
+    @Override
+    public FindCompanyInfoRes findCompanyId(String companyName) {
+        Company company = companyRepository.findByName(companyName)
+                .orElseThrow(() -> new BadRequestException(NOT_FOUND_COMPANY));
+        List<CompanyImage> companyImages = companyImageRepository.findAllByCompany(company);
+        return FindCompanyInfoRes.fromEntity(company, companyImages);
+    }
+}

--- a/backend/server/src/main/java/shop/sellution/server/company/dto/FindCompanyInfoRes.java
+++ b/backend/server/src/main/java/shop/sellution/server/company/dto/FindCompanyInfoRes.java
@@ -1,0 +1,61 @@
+package shop.sellution.server.company.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import shop.sellution.server.company.domain.Company;
+import shop.sellution.server.company.domain.CompanyImage;
+import shop.sellution.server.company.domain.type.ImagePurposeType;
+import shop.sellution.server.company.domain.type.SubscriptionType;
+import shop.sellution.server.global.type.DeliveryType;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class FindCompanyInfoRes {
+    private Long companyId; // 회사 id
+    private String displayName; // 로고 대신 보이는 회사명
+    private String name; // companyName
+    private String logoImageUrl;
+    private List<String> promotionImageUrls;
+    private DeliveryType serviceType; // 회사 서비스 유형 (단건, 정기, 둘다)
+    private SubscriptionType subscriptionType;
+    private int minDeliveryCount;
+    private int maxDeliveryCount;
+    private String themeColor;
+    private String mainPromotion1Title;
+    private String mainPromotion1Content;
+    private String mainPromotion2Title;
+    private String mainPromotion2Content;
+
+    public static FindCompanyInfoRes fromEntity(Company company, List<CompanyImage> companyImages) {
+        String logoImageUrl = companyImages.stream()
+                .filter(image -> image.getPurposeOfUse() == ImagePurposeType.LOGO)
+                .map(CompanyImage::getImageUrl)
+                .findFirst()
+                .orElse(null);
+
+        List<String> promotionImageUrls = companyImages.stream()
+                .filter(image -> image.getPurposeOfUse() == ImagePurposeType.PROMOTION)
+                .map(CompanyImage::getImageUrl)
+                .collect(Collectors.toList());
+
+        return FindCompanyInfoRes.builder()
+                .companyId(company.getCompanyId())
+                .displayName(company.getName())
+                .name(company.getName())
+                .serviceType(company.getServiceType())
+                .subscriptionType(company.getSubscriptionType())
+                .minDeliveryCount(company.getMinDeliveryCount())
+                .maxDeliveryCount(company.getMaxDeliveryCount())
+                .themeColor(company.getThemeColor())
+                .mainPromotion1Title(company.getMainPromotion1Title())
+                .mainPromotion1Content(company.getMainPromotion1Content())
+                .mainPromotion2Title(company.getMainPromotion2Title())
+                .mainPromotion2Content(company.getMainPromotion2Content())
+                .logoImageUrl(logoImageUrl)
+                .promotionImageUrls(promotionImageUrls)
+                .build();
+    }
+}

--- a/backend/server/src/main/java/shop/sellution/server/company/presentation/CompanyController.java
+++ b/backend/server/src/main/java/shop/sellution/server/company/presentation/CompanyController.java
@@ -1,17 +1,20 @@
 package shop.sellution.server.company.presentation;
 
 import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import shop.sellution.server.company.application.CompanyDisplaySettingServiceImpl;
 import shop.sellution.server.company.application.CompanySaleSettingServiceImpl;
+import shop.sellution.server.company.application.CompanyServiceImpl;
 import shop.sellution.server.company.application.CompanyUrlSettingServiceImpl;
 import shop.sellution.server.company.dto.*;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 //@RequestMapping("/sellsolution")
@@ -19,11 +22,13 @@ public class CompanyController {
     private final CompanyUrlSettingServiceImpl clientCompanyService;
     private final CompanyDisplaySettingServiceImpl clientCompanyDisplayService;
     private final CompanySaleSettingServiceImpl clientCompanySaleService;
+    private final CompanyServiceImpl companyService;
 
-    public CompanyController(CompanyUrlSettingServiceImpl clientCompanyService, CompanyDisplaySettingServiceImpl clientCompanyDisplayService, CompanySaleSettingServiceImpl clientCompanySaleService) {
+    public CompanyController(CompanyUrlSettingServiceImpl clientCompanyService, CompanyDisplaySettingServiceImpl clientCompanyDisplayService, CompanySaleSettingServiceImpl clientCompanySaleService, CompanyServiceImpl companyService) {
         this.clientCompanyService = clientCompanyService;
         this.clientCompanyDisplayService = clientCompanyDisplayService;
         this.clientCompanySaleService = clientCompanySaleService;
+        this.companyService = companyService;
     }
 
     @GetMapping("/url-setting/{companyId}")
@@ -70,10 +75,9 @@ public class CompanyController {
         return ResponseEntity.ok().build();
     }
 
-
-
-
-
-
-
+    @GetMapping("/shopping-find-companyId/{companyName}")
+    public ResponseEntity<Map<String, FindCompanyInfoRes>> getCompanyInfo(@PathVariable String companyName) {
+        FindCompanyInfoRes findCompanyInfo = companyService.findCompanyId(companyName);
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of("data", findCompanyInfo));
+    }
 }

--- a/backend/server/src/main/java/shop/sellution/server/customer/application/CustomerService.java
+++ b/backend/server/src/main/java/shop/sellution/server/customer/application/CustomerService.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import shop.sellution.server.customer.dto.CustomerSearchCondition;
 import shop.sellution.server.customer.dto.request.*;
+import shop.sellution.server.customer.dto.resonse.FindCurrentCustomerInfoRes;
 import shop.sellution.server.customer.dto.resonse.FindCustomerInfoRes;
 import shop.sellution.server.customer.dto.resonse.FindCustomerRes;
 
@@ -15,6 +16,9 @@ public interface CustomerService {
 
     // 회원 아이디 중복 확인
     void checkCustomerUsername(CheckCustomerUsernameReq request);
+
+    // 현재 고객 정보 가져오기
+    FindCurrentCustomerInfoRes getCurrentUserInfo();
 
     // 회원 아이디 찾기
     String findCustomerId(FindCustomerIdReq request);

--- a/backend/server/src/main/java/shop/sellution/server/customer/application/CustomerServiceImpl.java
+++ b/backend/server/src/main/java/shop/sellution/server/customer/application/CustomerServiceImpl.java
@@ -16,6 +16,7 @@ import shop.sellution.server.customer.domain.Customer;
 import shop.sellution.server.customer.domain.CustomerRepository;
 import shop.sellution.server.customer.dto.CustomerSearchCondition;
 import shop.sellution.server.customer.dto.request.*;
+import shop.sellution.server.customer.dto.resonse.FindCurrentCustomerInfoRes;
 import shop.sellution.server.customer.dto.resonse.FindCustomerInfoRes;
 import shop.sellution.server.customer.dto.resonse.FindCustomerRes;
 import shop.sellution.server.global.exception.AuthException;
@@ -64,6 +65,20 @@ public class CustomerServiceImpl implements CustomerService{
     @Transactional(readOnly = true)
     public void checkCustomerUsername(CheckCustomerUsernameReq request) {
         validateUniqueUsername(request.getCompanyId(), request.getUsername());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public FindCurrentCustomerInfoRes getCurrentUserInfo() {
+        CustomUserDetails customUserDetails = getCustomUserDetailsFromSecurityContext();
+        Customer customer = customerRepository.findById(customUserDetails.getUserId())
+                .orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_CUSTOMER));
+        return FindCurrentCustomerInfoRes.builder()
+                .id(customer.getId())
+                .companyId(customer.getCompany().getCompanyId())
+                .name(customer.getName())
+                .customerType(customer.getType())
+                .build();
     }
 
     @Override

--- a/backend/server/src/main/java/shop/sellution/server/customer/dto/resonse/FindCurrentCustomerInfoRes.java
+++ b/backend/server/src/main/java/shop/sellution/server/customer/dto/resonse/FindCurrentCustomerInfoRes.java
@@ -1,0 +1,18 @@
+package shop.sellution.server.customer.dto.resonse;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import shop.sellution.server.customer.domain.type.CustomerType;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class FindCurrentCustomerInfoRes {
+    private Long id;
+    private Long companyId;
+    private String name;
+    private CustomerType customerType;
+}

--- a/backend/server/src/main/java/shop/sellution/server/customer/presentation/CustomerController.java
+++ b/backend/server/src/main/java/shop/sellution/server/customer/presentation/CustomerController.java
@@ -13,6 +13,7 @@ import shop.sellution.server.customer.application.CustomerService;
 import shop.sellution.server.customer.domain.Customer;
 import shop.sellution.server.customer.dto.CustomerSearchCondition;
 import shop.sellution.server.customer.dto.request.*;
+import shop.sellution.server.customer.dto.resonse.FindCurrentCustomerInfoRes;
 import shop.sellution.server.customer.dto.resonse.FindCustomerInfoRes;
 import shop.sellution.server.customer.dto.resonse.FindCustomerRes;
 import shop.sellution.server.global.exception.AuthException;
@@ -41,6 +42,12 @@ public class CustomerController {
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("available", false));
         }
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<Map<String, FindCurrentCustomerInfoRes>> getCurrentCustomerInfo() {
+        FindCurrentCustomerInfoRes currentCustomerInfo = customerService.getCurrentUserInfo();
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of("data", currentCustomerInfo));
     }
 
     @PostMapping("/find-id")

--- a/frontend/sellution-app/src/shopping/business/home/useHome.js
+++ b/frontend/sellution-app/src/shopping/business/home/useHome.js
@@ -1,16 +1,31 @@
 import { useState, useEffect } from 'react';
-import axios from 'axios';
+// import axios from 'axios';
+import { getCompanyInfo } from '@/shopping/utility/apis/home/homeApi';
+import useCompanyInfoStore from '@/shopping/store/stores/useCompanyInfoStore';
+
+import { useParams } from 'react-router-dom';
 
 const useHome = () => {
   const [activeSlide, setActiveSlide] = useState(1);
   const [data, setData] = useState(null); // 데이터 상태 추가
 
+  const { clientName } = useParams(); // url 상 clientName <- 회사명
+
+  // localstorage에서 관리되는 회사 정보
+  // 추후 회사 정보가 필요한 작업에서 회사의 정보가 없다면 home으로 돌려보내야 합니다.
+  const { name, getAllCompanyData, setAllCompanyData } = useCompanyInfoStore((state) => ({
+    name: state.name,
+    getAllCompanyData: state.getAllCompanyData,
+    setAllCompanyData: state.setAllCompanyData,
+  }));
+
   useEffect(() => {
     // API 요청 함수
-    const fetchData = async () => {
+    const fetchData = async (clientName, setAllCompanyData) => {
       try {
-        const companyId = 1; // 실제로 사용할 companyId 값 설정
-        const response = await axios.get(`http://localhost:8080/display-setting/${companyId}`);
+        const response = await getCompanyInfo(clientName, setAllCompanyData);
+        // const companyId = 1; // 실제로 사용할 companyId 값 설정
+        // const response = await axios.get(`http://localhost:8080/display-setting/${companyId}`);
         setData(response.data);
         console.log('홈 화면 api 데이터 ', response.data);
       } catch (error) {
@@ -18,8 +33,12 @@ const useHome = () => {
       }
     };
 
-    fetchData(); // 데이터 요청 함수 호출
-  }, []); // 빈 배열을 두어 한 번만 실행되도록 설정
+    if (clientName != name) {
+      fetchData(clientName, setAllCompanyData); // 데이터 요청 함수 호출
+    } else {
+      setData({ ...getAllCompanyData() });
+    }
+  }, [clientName]); // 빈 배열을 두어 한 번만 실행되도록 설정 -> url의 clientName이 변경될 때마다 재 요청
 
   useEffect(() => {
     const totalSlides =

--- a/frontend/sellution-app/src/shopping/business/login/useLogin.js
+++ b/frontend/sellution-app/src/shopping/business/login/useLogin.js
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import useAuthStore from '@/shopping/store/stores/useAuthStore';
+import useUserInfoStore from '@/shopping/store/stores/useUserInfoStore';
+import useCompanyInfoStore from '@/shopping/store/stores/useCompanyInfoStore';
+import { login } from '@/shopping/utility/apis/login/loginApi';
+
+export const useLogin = () => {
+  const navigate = useNavigate();
+  const { clientName } = useParams(); // url 상 clientName <- 회사명
+
+  const setAccessToken = useAuthStore((state) => state.setAccessToken);
+  const setAllUserData = useUserInfoStore((state) => state.setAllUserData);
+  //local에 저장된 회사명, 회사 id
+  const { name, companyId } = useCompanyInfoStore((state) => ({
+    name: state.name,
+    companyId: state.companyId,
+  }));
+
+  const [showPassword, setShowPassword] = useState(false);
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  // 비밀번호 표시 여부 토글
+  const togglePasswordVisibility = () => {
+    setShowPassword(!showPassword);
+  };
+
+  // 로그인 제출 핸들러
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!username && !password) {
+      setError('아이디와 비밀번호를 입력해주세요.');
+    } else if (!username) {
+      setError('아이디를 입력해주세요.');
+    } else if (!password) {
+      setError('비밀번호를 입력해주세요.');
+    } else {
+      setError('');
+      setIsLoading(true);
+      try {
+        const success = await login(username, password, companyId, setAccessToken, setAllUserData);
+        if (success) {
+          navigate(`/shopping/${name}/home`); // 로그인 성공 시 홈으로 이동
+        } else {
+          setError('로그인에 실패했습니다. 아이디와 비밀번호를 확인해주세요.');
+        }
+      } catch (error) {
+        setError('로그인 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+      } finally {
+        setIsLoading(false);
+      }
+    }
+  };
+
+  // url의 회사명과 localstorage에 저장된 회사명이 다른 경우, url 회사명에 대한 home으로 이동
+  useEffect(() => {
+    if (clientName !== name) {
+      navigate(`/shopping/${clientName}/home`);
+    }
+  }, []);
+
+  return {
+    username,
+    password,
+    showPassword,
+    error,
+    isLoading,
+    setUsername,
+    setPassword,
+    togglePasswordVisibility,
+    handleSubmit,
+  };
+};

--- a/frontend/sellution-app/src/shopping/component/login/LoginComponent.jsx
+++ b/frontend/sellution-app/src/shopping/component/login/LoginComponent.jsx
@@ -1,66 +1,162 @@
 import { useState } from 'react';
-const LoginComponent = () => {
-  const [id, setId] = useState('');
-  const [password, setPassword] = useState('');
+import { useLogin } from '@/shopping/business/login/useLogin';
+import { LogoIcon } from '@/client/utility/assets/LoginIcons';
+import { EyeOnIcon, EyeOffIcon } from '@/client/utility/assets/Icons';
 
-  const handleLogin = (e) => {
-    e.preventDefault();
-    console.log('로그인 시도:', { id, password });
-    // 여기에 로그인 로직을 구현합니다
-  };
+import LogoHeaderNav from '@/shopping/layout/LogoHeaderNav';
+import HomeFooter from '@/shopping/layout/HomeFooter';
+
+const LoginComponent = () => {
+  const {
+    username,
+    password,
+    showPassword,
+    error,
+    isLoading,
+    setUsername,
+    setPassword,
+    togglePasswordVisibility,
+    handleSubmit,
+  } = useLogin();
+
   return (
-    <div className='w-full flex justify-center'>
-      <div className='w-[85%] p-6 bg-white rounded-lg shadow-md'>
-        <form onSubmit={handleLogin} className='space-y-4'>
-          <div>
-            <label htmlFor='id' className='block text-sm font-medium text-gray-700'>
-              아이디
-            </label>
-            <input
-              id='id'
-              type='text'
-              value={id}
-              onChange={(e) => setId(e.target.value)}
-              className='mt-1 block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500'
-              placeholder='아이디'
-            />
+    <>
+      <LogoHeaderNav logoImageUrl={null} />
+      {/* <div className='w-full bg-red-500'>
+        <div className='w-[85%] p-6 bg-white rounded-lg shadow-md'>
+          <form onSubmit={handleLogin} className='space-y-4'>
+            <div>
+              <label htmlFor='id' className='block text-sm font-medium text-gray-700'>
+                아이디
+              </label>
+              <input
+                id='id'
+                type='text'
+                value={id}
+                onChange={(e) => setId(e.target.value)}
+                className='mt-1 block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500'
+                placeholder='아이디'
+              />
+            </div>
+            <div>
+              <label htmlFor='password' className='block text-sm font-medium text-gray-700'>
+                비밀번호
+              </label>
+              <input
+                id='password'
+                type='password'
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className='mt-1 block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500'
+                placeholder='비밀번호'
+              />
+            </div>
+            <div className='flex justify-between text-sm'>
+              <a
+                href='#'
+                className='text-gray-400 hover:text-gray-800 flex items-center gap-2 text-xs hover:text-gray-500'
+              >
+                <span>아이디/비밀번호 찾기</span>
+                <span></span>
+              </a>
+            </div>
+            <div className='flex space-x-2'>
+              <button
+                type='button'
+                className='flex-1 px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500'
+              >
+                회원가입
+              </button>
+              <button
+                type='submit'
+                className='flex-1 px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-orange-500 hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500'
+              >
+                로그인
+              </button>
+            </div>
+          </form>
+        </div>
+      </div> */}
+      <div className='relative w-full h-full bg-white'>
+        <div className='absolute w-full h-fit top-[10%] bg-red-500 flex items-start justify-center p-4 flex-1'>
+          <div className='w-full max-w-md min-h-[400px] max-h-[600px] p-8 flex flex-col justify-between bg-white shadow-md rounded-lg'>
+            <div className='space-y-8'>
+              <form onSubmit={handleSubmit} className='pt-10 space-y-6'>
+                <div>
+                  <label
+                    htmlFor='username'
+                    className='block text-sm font-medium text-gray-700 mb-2'
+                  >
+                    아이디
+                  </label>
+                  <input
+                    id='username'
+                    name='username'
+                    type='text'
+                    autoComplete='username'
+                    value={username}
+                    onChange={(e) => setUsername(e.target.value)}
+                    className='w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-brandOrange focus:border-brandOrange'
+                    placeholder='아이디를 입력하세요'
+                  />
+                </div>
+                <div>
+                  <label
+                    htmlFor='password'
+                    className='block text-sm font-medium text-gray-700 mb-2'
+                  >
+                    비밀번호
+                  </label>
+                  <div className='relative'>
+                    <input
+                      id='password'
+                      name='password'
+                      type={showPassword ? 'text' : 'password'}
+                      autoComplete='current-password'
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      className='w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-orange-500'
+                      placeholder='비밀번호를 입력하세요'
+                    />
+                    <button
+                      type='button'
+                      className='absolute inset-y-0 right-0 pr-3 flex items-center text-sm leading-5'
+                      onClick={togglePasswordVisibility}
+                    >
+                      {showPassword ? (
+                        <EyeOnIcon className='h-5 w-5 text-gray-500' />
+                      ) : (
+                        <EyeOffIcon className='h-5 w-5 text-gray-500' />
+                      )}
+                    </button>
+                  </div>
+                </div>
+                {error && <div className='text-red-500 text-sm mt-2'>{error}</div>}
+                <div className='pt-4'>
+                  <button
+                    type='submit'
+                    className='w-full flex justify-center py-3 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-brandOrange hover:bg-brandOrange focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brandOrange transition-all duration-300 ease-in-out transform hover:scale-102'
+                    disabled={isLoading}
+                  >
+                    {isLoading ? '로그인 중...' : '로그인'}
+                  </button>
+                </div>
+              </form>
+            </div>
+            <div className='w-full text-center text-sm mt-8 flex justify-center items-center'>
+              <div className='font-medium text-brandOrange hover:text-brandOrange'>아이디 찾기</div>
+              <div className='divider divider-horizontal'></div>
+              <div className='font-medium text-brandOrange hover:text-brandOrange'>
+                비밀번호 찾기
+              </div>
+              <div className='divider divider-horizontal'></div>
+              <div className='font-medium text-brandOrange hover:text-brandOrange'>아이디 생성</div>
+            </div>
           </div>
-          <div>
-            <label htmlFor='password' className='block text-sm font-medium text-gray-700'>
-              비밀번호
-            </label>
-            <input
-              id='password'
-              type='password'
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              className='mt-1 block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500'
-              placeholder='비밀번호'
-            />
-          </div>
-          <div className='flex justify-between text-sm'>
-            <a href='#' className='text-gray-400 hover:text-gray-800 flex items-center gap-2 text-xs hover:text-gray-500'>
-              <span>아이디/비밀번호 찾기</span>
-              <span>></span>
-            </a>
-          </div>
-          <div className='flex space-x-2'>
-            <button
-              type='button'
-              className='flex-1 px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500'
-            >
-              회원가입
-            </button>
-            <button
-              type='submit'
-              className='flex-1 px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-orange-500 hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500'
-            >
-              로그인
-            </button>
-          </div>
-        </form>
+        </div>
       </div>
-    </div>
+      <HomeFooter></HomeFooter>
+    </>
   );
 };
 

--- a/frontend/sellution-app/src/shopping/layout/HomeFooter.jsx
+++ b/frontend/sellution-app/src/shopping/layout/HomeFooter.jsx
@@ -7,8 +7,11 @@ import {
   MypageIcon,
   CartIcon,
 } from '../utility/assets/Icons';
+import useAuthStore from '@/shopping/store/stores/useAuthStore';
 
 const HomeFooter = () => {
+  const accessToken = useAuthStore((state) => state.accessToken);
+  console.log(accessToken);
   const { clientName } = useClientName();
   const { customerId } = useParams();
   return (
@@ -35,7 +38,11 @@ const HomeFooter = () => {
         <p className='text-brandOrange text-xs font-bold pt-1'>단건주문</p>
       </Link>
       <Link
-        to={`/shopping/${clientName}/my/${customerId}`}
+        to={
+          accessToken === null || accessToken === ''
+            ? `/shopping/${clientName}/login`
+            : `/shopping/${clientName}/my/${customerId}`
+        }
         className='flex-1 bg-white flex flex-col justify-center items-center relative'
       >
         <MypageIcon className='w-7 h-7 fill-current text-brandOrange stroke-brandOrange stroke-[10]' />

--- a/frontend/sellution-app/src/shopping/store/stores/useCompanyInfoStore.js
+++ b/frontend/sellution-app/src/shopping/store/stores/useCompanyInfoStore.js
@@ -1,0 +1,88 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+// 회사 정보를 전역 관리하는 공간
+const useCompanyInfoStore = create(
+  persist(
+    (set, get) => ({
+      companyId: null,
+      displayName: '',
+      name: '',
+      logoImageUrl: null,
+      promotionImageUrls: [],
+      serviceType: '',
+      subscriptionType: '',
+      minDeliveryCount: 0,
+      maxDeliveryCount: 0,
+      themeColor: '',
+      mainPromotion1Title: '',
+      mainPromotion1Content: '',
+      mainPromotion2Title: '',
+      mainPromotion2Content: '',
+
+      // 모든 데이터를 한 번에 설정하는 함수
+      setAllCompanyData: (data) =>
+        set({
+          companyId: data.companyId,
+          displayName: data.displayName,
+          name: data.name,
+          logoImageUrl: data.logoImageUrl,
+          promotionImageUrls: data.promotionImageUrls,
+          serviceType: data.serviceType,
+          subscriptionType: data.subscriptionType,
+          minDeliveryCount: data.minDeliveryCount,
+          maxDeliveryCount: data.maxDeliveryCount,
+          themeColor: data.themeColor,
+          mainPromotion1Title: data.mainPromotion1Title,
+          mainPromotion1Content: data.mainPromotion1Content,
+          mainPromotion2Title: data.mainPromotion2Title,
+          mainPromotion2Content: data.mainPromotion2Content,
+        }),
+
+      // 모든 데이터를 한 번에 가져오는 함수
+      getAllCompanyData: () => {
+        const state = get();
+        return {
+          companyId: state.companyId,
+          displayName: state.displayName,
+          name: state.name,
+          logoImageUrl: state.logoImageUrl,
+          promotionImageUrls: state.promotionImageUrls,
+          serviceType: state.serviceType,
+          subscriptionType: state.subscriptionType,
+          minDeliveryCount: state.minDeliveryCount,
+          maxDeliveryCount: state.maxDeliveryCount,
+          themeColor: state.themeColor,
+          mainPromotion1Title: state.mainPromotion1Title,
+          mainPromotion1Content: state.mainPromotion1Content,
+          mainPromotion2Title: state.mainPromotion2Title,
+          mainPromotion2Content: state.mainPromotion2Content,
+        };
+      },
+
+      clearCompanyData: () =>
+        set({
+          companyId: null,
+          displayName: '',
+          name: '',
+          logoImageUrl: null,
+          promotionImageUrls: [],
+          serviceType: '',
+          subscriptionType: '',
+          minDeliveryCount: 0,
+          maxDeliveryCount: 0,
+          themeColor: '',
+          mainPromotion1Title: '',
+          mainPromotion1Content: '',
+          mainPromotion2Title: '',
+          mainPromotion2Content: '',
+        }),
+    }),
+    {
+      name: 'shop-company-storage',
+      getStorage: () => localStorage,
+    },
+  ),
+);
+
+export default useCompanyInfoStore;

--- a/frontend/sellution-app/src/shopping/store/stores/useUserInfoStore.js
+++ b/frontend/sellution-app/src/shopping/store/stores/useUserInfoStore.js
@@ -1,0 +1,43 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+const useUserInfoStore = create(
+  persist(
+    (set) => ({
+      id: null,
+      companyId: null,
+      name: '',
+      customerType: '',
+
+      // 모든 사용자 데이터를 한 번에 설정하는 함수
+      setAllUserData: (data) =>
+        set({
+          id: data.id,
+          companyId: data.companyId,
+          name: data.name,
+          customerType: data.customerType,
+        }),
+
+      // 개별 필드 setter 함수들
+      setId: (id) => set({ id }),
+      setCompanyId: (companyId) => set({ companyId }),
+      setName: (name) => set({ name }),
+      setCustomerType: (customerType) => set({ customerType }),
+
+      // 사용자 데이터를 초기화하는 함수
+      clearUserData: () =>
+        set({
+          id: null,
+          companyId: null,
+          name: '',
+          customerType: '',
+        }),
+    }),
+    {
+      name: 'shop-user-storage', // localStorage에 저장될 키 이름
+      getStorage: () => localStorage, // 사용할 스토리지 지정
+    },
+  ),
+);
+
+export default useUserInfoStore;

--- a/frontend/sellution-app/src/shopping/utility/apis/home/homeApi.js
+++ b/frontend/sellution-app/src/shopping/utility/apis/home/homeApi.js
@@ -1,0 +1,18 @@
+import BaseInstance from '@/shopping/utility/axios/BaseInstance';
+
+const API_URL_1 = '/shopping-find-companyId';
+
+//회사 정보 가져오기
+export const getCompanyInfo = async (clientName, setAllCompanyData) => {
+  try {
+    const url = `${API_URL_1}/${clientName}`;
+    let instance = await BaseInstance();
+    const response = await instance.get(url);
+    await setAllCompanyData(response.data.data); // zustand에 보관
+    return response.data;
+  } catch (error) {
+    console.log('Login faild:', error);
+    // window.location.href = '/shopping-404';
+    return;
+  }
+};

--- a/frontend/sellution-app/src/shopping/utility/apis/login/loginApi.js
+++ b/frontend/sellution-app/src/shopping/utility/apis/login/loginApi.js
@@ -1,0 +1,33 @@
+import BaseInstance from '@/client/utility/axios/BaseInstance';
+import { addAuthInterceptor } from '@/client/utility/axios/Interceptors';
+
+const API_URL_1 = '/login';
+const API_URL_2 = '/api/customers/me';
+
+// 로그인 기능
+export const login = async (username, password, companyId, setAccessToken, setAllUserData) => {
+  try {
+    // 로그인
+    let instance = await BaseInstance('FORM');
+    const response = await instance.post(API_URL_1, {
+      username,
+      password,
+      companyId,
+      role: 'ROLE_CUSTOMER',
+    });
+
+    const accessToken = response.headers.get('Authorization').split(' ')[1];
+    setAccessToken(accessToken);
+
+    // 고객 이름 조회
+    let newInstance = await BaseInstance();
+    instance = await addAuthInterceptor(newInstance, setAccessToken, accessToken);
+    const newResponse = await instance.get(API_URL_2);
+
+    setAllUserData(newResponse.data.data);
+    return true;
+  } catch (error) {
+    console.error('Login faild:', error);
+    return false;
+  }
+};


### PR DESCRIPTION
## :: 작업 내용
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
- [ ] 테스트

## :: 구현 목표
- 회원 로그인 api 연결 및 사업체 정보 조회 api 연결

## :: 구현 사항 설명
- 사업체 정보 조회 api 연결 : 홈 화면 랜더링 시 사업체 정보를 조회해서 로컬 스토리지에 영속적으로 저장
- 회원 로그인 api 연결 : 로그인 시 사용자의 정보를 로컬 스토리지에 영속적으로 저장

## :: 특이 사항
- 다른 페이지를 구현할 때, url에 있는 사업체명(clientName)과 로컬 스토리지에 있는 사업체명(name) 이 동일한지 useEffect로 첫 렌더링 시 비교하는 로직을 반드시!!! 구현하셔야 합니다.
-  UI 부분은 추후 다듬겠습니다....

## :: Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요
> 개발 과정에서 다른 분들의 의견은 어떠한지 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요
*

### :: 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
#