### PR TITLE
[K1P-244] back - 주문취소시 쿠폰 미사용상태로 변경, 배송시점에 재고없을시 주문취소, 간편비밀번호 암호화처리, 해당주문 재고파악 API추가

### DIFF
--- a/backend/server/src/main/java/shop/sellution/server/account/dto/response/CheckAccountRes.java
+++ b/backend/server/src/main/java/shop/sellution/server/account/dto/response/CheckAccountRes.java
@@ -1,10 +1,12 @@
 package shop.sellution.server.account.dto.response;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@Builder
 public class CheckAccountRes {
 
     private final String bankHolderName;

--- a/backend/server/src/main/java/shop/sellution/server/easypwd/application/EasyPwdServiceImpl.java
+++ b/backend/server/src/main/java/shop/sellution/server/easypwd/application/EasyPwdServiceImpl.java
@@ -1,6 +1,7 @@
 package shop.sellution.server.easypwd.application;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.sellution.server.customer.domain.Customer;
@@ -9,32 +10,39 @@ import shop.sellution.server.easypwd.dto.request.EasyPwdReq;
 import shop.sellution.server.global.exception.BadRequestException;
 import shop.sellution.server.global.exception.ExceptionCode;
 
+import static shop.sellution.server.global.exception.ExceptionCode.INVALID_EASY_PWD;
+import static shop.sellution.server.global.exception.ExceptionCode.NOT_FOUND_CUSTOMER;
+
 @Service
 @RequiredArgsConstructor
 public class EasyPwdServiceImpl implements EasyPwdService {
 
     private final CustomerRepository customerRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Override
     @Transactional
     public void registerEasyPwd(Long customerId, EasyPwdReq req) {
         Customer customer = customerRepository.findById(customerId)
-                .orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_CUSTOMER));
-        customer.changeEasyPwd(req.getPassword());
+                .orElseThrow(() -> new BadRequestException(NOT_FOUND_CUSTOMER));
+        String encodedEasyPwd = passwordEncoder.encode(req.getPassword());
+        customer.changeEasyPwd(encodedEasyPwd);
     }
 
     @Override
     public void verifyEasyPwd(Long customerId, EasyPwdReq easyPwdReq) {
-        customerRepository.findById(customerId)
-                .orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_CUSTOMER))
-                .verifyEasyPwd(easyPwdReq.getPassword());
-
+        Customer customer = customerRepository.findById(customerId)
+                .orElseThrow(() -> new BadRequestException(NOT_FOUND_CUSTOMER));
+        String easyPwd = customer.getEasyPwd();
+        if (!passwordEncoder.matches(easyPwdReq.getPassword(), easyPwd)) {
+            throw new BadRequestException(INVALID_EASY_PWD);
+        }
     }
 
     @Override
     public boolean checkEasyPwd(Long customerId) {
         Customer customer = customerRepository.findById(customerId)
-                .orElseThrow(() -> new BadRequestException(ExceptionCode.NOT_FOUND_CUSTOMER));
+                .orElseThrow(() -> new BadRequestException(NOT_FOUND_CUSTOMER));
         return customer.getEasyPwd() != null && !customer.getEasyPwd().isEmpty();
 
     }

--- a/backend/server/src/main/java/shop/sellution/server/event/domain/CouponBox.java
+++ b/backend/server/src/main/java/shop/sellution/server/event/domain/CouponBox.java
@@ -31,5 +31,15 @@ public class CouponBox {
     @Builder.Default
     private DisplayStatus isUsed = DisplayStatus.N;
 
+    // 쿠폰 사용처리
+    public void useCoupon() {
+        this.isUsed = DisplayStatus.Y;
+    }
+
+    // 쿠폰 미사용처리
+    public void unUseCoupon() {
+        this.isUsed = DisplayStatus.N;
+    }
+
 
 }

--- a/backend/server/src/main/java/shop/sellution/server/event/domain/CouponBoxRepository.java
+++ b/backend/server/src/main/java/shop/sellution/server/event/domain/CouponBoxRepository.java
@@ -1,12 +1,24 @@
 package shop.sellution.server.event.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import shop.sellution.server.customer.domain.Customer;
+
+import java.util.Optional;
 
 @Repository
 public interface CouponBoxRepository extends JpaRepository<CouponBox, CouponBoxId> {
     boolean existsByCustomerIdAndCouponEventId(Long customerId, Long eventId);
 
     long countByCouponEvent_Id(Long couponEventId);
+
+    // 쿠폰 이벤트와 사용자아이디를 통해 쿠폰박스를 조회한다.
+    @Query("""
+            select cb from CouponBox cb
+            where cb.couponEvent = :couponEvent
+            and cb.customer = :customer
+            """)
+    Optional<CouponBox> findByCouponEventAndCustomerId(CouponEvent couponEvent, Customer customer);
 
 }

--- a/backend/server/src/main/java/shop/sellution/server/global/DataInitializer.java
+++ b/backend/server/src/main/java/shop/sellution/server/global/DataInitializer.java
@@ -48,7 +48,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAdjusters;
 import java.util.*;
 
-@Profile("prod")
+@Profile("data")
 @Component
 @RequiredArgsConstructor
 @Slf4j
@@ -142,10 +142,10 @@ public class DataInitializer implements ApplicationListener<ContextRefreshedEven
 //        createProductImages();
         createProductImages2();
         createCustomer();
-//        createAccount();
-//        createAddress();
+        createAccount();
+        createAddress();
         createCompanyOptions();
-//        createCouponEvent();
+        createCouponEvent();
 //        createOrder();
 
 

--- a/backend/server/src/main/java/shop/sellution/server/global/exception/ExceptionCode.java
+++ b/backend/server/src/main/java/shop/sellution/server/global/exception/ExceptionCode.java
@@ -79,6 +79,9 @@ public enum ExceptionCode {
     INVALID_ORDER_INFO_FOR_ONETIME(5018,"단건 주문에 유효하지않은 정보값입니다." ),
     INVALID_ORDER_INFO_FOR_SUB(5018,"정기 주문에 유효하지않은 정보값입니다." ),
     ALREADY_ACCOUNT(5019,"이미 등록된 계좌입니다." ),
+    NOT_FOUND_COUPON(5020,"없는 쿠폰입니다." ),
+    ALREADY_USED_COUPON(5021,"이미 사용된 쿠폰입니다." ),
+    INVALID_EASY_PWD(5022,"간편비밀번호가 틀렸습니다." ),
 
 
 
@@ -128,7 +131,7 @@ public enum ExceptionCode {
 
 
     EXTERNAL_SEVER_ERROR(9998, "외부 서버 에러가 발생하였습니다. 관리자에게 문의해 주세요."),
-    INTERNAL_SEVER_ERROR(9999, "서버 에러가 발생하였습니다. 관리자에게 문의해 주세요.");
+    INTERNAL_SEVER_ERROR(9999, "서버 에러가 발생하였습니다. 관리자에게 문의해 주세요."), ;
 
     private final int code;
     private final String message;

--- a/backend/server/src/main/java/shop/sellution/server/order/application/OrderCreationService.java
+++ b/backend/server/src/main/java/shop/sellution/server/order/application/OrderCreationService.java
@@ -18,9 +18,12 @@ import shop.sellution.server.company.domain.repository.WeekOptionRepository;
 import shop.sellution.server.company.domain.type.DayValueType;
 import shop.sellution.server.customer.domain.Customer;
 import shop.sellution.server.customer.domain.CustomerRepository;
+import shop.sellution.server.event.domain.CouponBox;
+import shop.sellution.server.event.domain.CouponBoxRepository;
 import shop.sellution.server.event.domain.CouponEvent;
 import shop.sellution.server.event.domain.EventRepository;
 import shop.sellution.server.global.exception.BadRequestException;
+import shop.sellution.server.global.type.DisplayStatus;
 import shop.sellution.server.order.domain.*;
 import shop.sellution.server.order.domain.repository.OrderRepository;
 import shop.sellution.server.order.domain.type.OrderStatus;
@@ -64,6 +67,7 @@ public class OrderCreationService {
     private final SmsServiceImpl smsService;
     private final EventRepository eventRepository;
     private final PaymentUtil paymentUtil;
+    private final CouponBoxRepository couponBoxRepository;
 
 
     private static final int ONETIME = 1;
@@ -106,6 +110,12 @@ public class OrderCreationService {
         if(saveOrderReq.getEventId()!=null){
             couponEvent = eventRepository.findById(saveOrderReq.getEventId()).
                     orElseThrow( ()-> new BadRequestException(NOT_FOUND_EVENT) );
+            CouponBox couponBox = couponBoxRepository.findByCouponEventAndCustomerId(couponEvent, customer)
+                    .orElseThrow(() -> new BadRequestException(NOT_FOUND_COUPON));
+            if(couponBox.getIsUsed() == DisplayStatus.Y){
+                throw new BadRequestException(ALREADY_USED_COUPON);
+            }
+            couponBox.useCoupon(); // 쿠폰 사용처리
         }
 
 

--- a/backend/server/src/main/java/shop/sellution/server/order/application/OrderService.java
+++ b/backend/server/src/main/java/shop/sellution/server/order/application/OrderService.java
@@ -31,4 +31,5 @@ public interface OrderService {
     // 정기주문(월)을 위한 계산로직
     CalculateRes calculatePrice(CalculateReq calculateReq);
 
+    boolean checkStock(Long orderId);
 }

--- a/backend/server/src/main/java/shop/sellution/server/order/application/OrderServiceImpl.java
+++ b/backend/server/src/main/java/shop/sellution/server/order/application/OrderServiceImpl.java
@@ -12,8 +12,12 @@ import shop.sellution.server.company.domain.repository.CompanyRepository;
 import shop.sellution.server.company.domain.type.DayValueType;
 import shop.sellution.server.customer.domain.Customer;
 import shop.sellution.server.customer.domain.CustomerRepository;
+import shop.sellution.server.event.domain.CouponBox;
+import shop.sellution.server.event.domain.CouponBoxRepository;
+import shop.sellution.server.event.domain.CouponEvent;
 import shop.sellution.server.event.domain.EventRepository;
 import shop.sellution.server.global.exception.BadRequestException;
+import shop.sellution.server.global.type.DisplayStatus;
 import shop.sellution.server.order.domain.*;
 import shop.sellution.server.order.domain.repository.OrderRepository;
 import shop.sellution.server.order.domain.repository.OrderedProductRepository;
@@ -66,6 +70,7 @@ public class OrderServiceImpl implements OrderService {
     private final OrderedProductRepository orderedProductRepository;
     private final EventRepository eventRepository;
     private final PaymentUtil paymentUtil;
+    private final CouponBoxRepository couponBoxRepository;
 
     // 특정 회원의 주문 목록 조회
     @Override
@@ -221,13 +226,19 @@ public class OrderServiceImpl implements OrderService {
             throw new BadRequestException(ALREADY_DELIVERED);
         }
 
-        // 승인된 주문인지 확인
-        if (order.getStatus() == OrderStatus.APPROVED) {
-            throw new BadRequestException(ALREADY_APPROVED_ORDER);
-        }
-
-
         order.cancelOrder();
+
+        // 배송전이라면 쿠폰 미사용으로 바꿔준다.
+        if (order.getDeliveryStatus() == DeliveryStatus.BEFORE_DELIVERY) {
+            CouponEvent couponEvent=null;
+            if(order.getCouponEvent()!=null){
+                couponEvent = eventRepository.findById(order.getCouponEvent().getId()).
+                        orElseThrow( ()-> new BadRequestException(NOT_FOUND_EVENT) );
+                CouponBox couponBox = couponBoxRepository.findByCouponEventAndCustomerId(couponEvent, customer)
+                        .orElseThrow(() -> new BadRequestException(NOT_FOUND_COUPON));
+                couponBox.unUseCoupon(); // 쿠폰 미사용처리
+            }
+        }
 
         /*
         결제를 진행해서 결제내역이 남아있고, 그 결제내역의 내용을 살펴봤을때
@@ -340,5 +351,21 @@ public class OrderServiceImpl implements OrderService {
             this.nextDeliveryDate = nextDeliveryDate;
             this.deliveryEndDate = deliveryEndDate;
         }
+    }
+
+    @Override
+    public boolean checkStock(Long orderId) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new BadRequestException(NOT_FOUND_ORDER));
+
+        List<OrderedProduct> orderedProducts = orderedProductRepository.findAllByOrderIdIn(List.of(orderId));
+
+        for (OrderedProduct orderedProduct : orderedProducts) {
+            if (orderedProduct.getProduct().getStock() < orderedProduct.getCount()) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/backend/server/src/main/java/shop/sellution/server/order/domain/Order.java
+++ b/backend/server/src/main/java/shop/sellution/server/order/domain/Order.java
@@ -190,5 +190,4 @@ public class Order extends BaseEntity {
     }
 
 
-
 }

--- a/backend/server/src/main/java/shop/sellution/server/order/presentation/OrderController.java
+++ b/backend/server/src/main/java/shop/sellution/server/order/presentation/OrderController.java
@@ -1,6 +1,5 @@
 package shop.sellution.server.order.presentation;
 
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -86,6 +85,12 @@ public class OrderController {
     @PostMapping("/count/info")
     public ResponseEntity<CalculateRes> getCountOrderDeliveryInfo(@RequestBody CalculateReq calculateReq) {
         return ResponseEntity.ok(orderService.calculatePrice(calculateReq));
+    }
+
+    // 해당 주문의 재고가 충분한지 체크 하는 API
+    @GetMapping("/{orderId}/enough-stock")
+    public ResponseEntity<String> checkStock(@PathVariable Long orderId) {
+        return ResponseEntity.ok(orderService.checkStock(orderId) ? "true" : "false");
     }
 
 

--- a/backend/server/src/main/java/shop/sellution/server/payment/dto/response/FindPaymentHistoryDetailRes.java
+++ b/backend/server/src/main/java/shop/sellution/server/payment/dto/response/FindPaymentHistoryDetailRes.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 @Builder
 public class FindPaymentHistoryDetailRes {
 
-    private Long paymentHisoryId;
+    private Long paymentHistoryId;
     private int price;
     private int remainingPayCount; // 남은 결제 횟수
     private int totalCountForPayment; // 총 결제해야하는 횟수
@@ -29,7 +29,7 @@ public class FindPaymentHistoryDetailRes {
 
     public static FindPaymentHistoryDetailRes fromEntity(PaymentHistory paymentHistory, String decryptedAccountNumber) {
         return FindPaymentHistoryDetailRes.builder()
-                .paymentHisoryId(paymentHistory.getId())
+                .paymentHistoryId(paymentHistory.getId())
                 .price(paymentHistory.getPrice())
                 .remainingPayCount(paymentHistory.getRemainingPaymentCount())
                 .totalCountForPayment(paymentHistory.getTotalPaymentCount())

--- a/backend/server/src/test/java/shop/sellution/server/account/application/AccountServiceImplTest.java
+++ b/backend/server/src/test/java/shop/sellution/server/account/application/AccountServiceImplTest.java
@@ -1,173 +1,204 @@
-//package shop.sellution.server.account.application;
-//
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//import org.springframework.data.domain.*;
-//import org.springframework.test.util.ReflectionTestUtils;
-//import shop.sellution.server.account.domain.Account;
-//import shop.sellution.server.account.domain.AccountRepository;
-//import shop.sellution.server.account.domain.type.BankCode;
-//import shop.sellution.server.account.dto.request.CheckAccountReq;
-//import shop.sellution.server.account.dto.request.SaveAccountReq;
-//import shop.sellution.server.account.dto.request.UpdateAccountReq;
-//import shop.sellution.server.account.dto.response.CheckAccountRes;
-//import shop.sellution.server.account.dto.response.FindAccountRes;
-//import shop.sellution.server.account.infrastructure.AccountAuthService;
-//import shop.sellution.server.customer.domain.Customer;
-//import shop.sellution.server.customer.domain.CustomerRepository;
-//import shop.sellution.server.global.exception.BadRequestException;
-//import shop.sellution.server.global.util.JasyptEncryptionUtil;
-//
-//import java.util.List;
-//import java.util.Optional;
-//
-//import static org.assertj.core.api.Assertions.*;
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.Mockito.*;
-//
-//@ExtendWith(MockitoExtension.class)
-//class AccountServiceImplTest {
-//
-//    @Mock
-//    private AccountRepository accountRepository;
-//
-//    @Mock
-//    private CustomerRepository customerRepository;
-//
-//    @Mock
-//    private AccountAuthService accountAuthService;
-//
-//    @Mock
-//    private JasyptEncryptionUtil jasyptEncryptionUtil;
-//
-//    @InjectMocks
-//    private AccountServiceImpl accountService;
-//
-//    @DisplayName("계좌 목록을 조회한다")
-//    @Test
-//    void findAllAccountsByCustomerId_Success() {
-//        // given
-//        Pageable pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
-//        Customer customer = Customer.builder().build();
-//        ReflectionTestUtils.setField(customer, "id", 1L);
-//
-//        List<Account> accounts = List.of(
-//                Account.builder().accountNumber("427502039102").bankCode(BankCode.KB.getBackCode()).customer(customer).build(),
-//                Account.builder().accountNumber("3333089607493").bankCode(BankCode.KAKAO.getBackCode()).customer(customer).build()
-//        );
-//        Page<Account> accountPage = new PageImpl<>(accounts, pageable, accounts.size());
-//
-//        when(accountRepository.findAllByCustomerId(1L, pageable)).thenReturn(accountPage);
-//
-//        // when
-//        Page<FindAccountRes> result = accountService.findAllAccountsByCustomerId(1L, pageable);
-//
-//        // then
-//        assertThat(result.getContent()).hasSize(2);
-//        assertThat(result.getContent().get(0).getAccountNumber()).isEqualTo("427502039102");
-//        assertThat(result.getContent().get(1).getAccountNumber()).isEqualTo("3333089607493");
-//        assertThat(result.getTotalElements()).isEqualTo(2);
-//
-//        verify(accountRepository).findAllByCustomerId(1L, pageable);
-//    }
-//
-//    @DisplayName("계좌를 생성한다.")
-//    @Test
-//    void saveAccount_Success() {
-//        // Given
-//        Long customerId = 1L;
-//        SaveAccountReq saveAccountReq = new SaveAccountReq();
-//        saveAccountReq.setAccountNumber("42750204039102");
-//        saveAccountReq.setBankCode("004");
-//
-//        Customer customer = Customer.builder().build();
-//        ReflectionTestUtils.setField(customer, "id", 1L);
-//
-//        CheckAccountRes checkAccountRes = new CheckAccountRes("Test User");
-//[K1P-230] back
-//        when(customerRepository.findById(customerId)).thenReturn(Optional.of(customer));
-//        when(accountAuthService.checkAccount(any(CheckAccountReq.class))).thenReturn(checkAccountRes);
-//        when(jasyptEncryptionUtil.encrypt(anyString())).thenReturn("encryptedAccountNumber");
-//
-//        // When
-//        accountService.saveAccount(customerId, saveAccountReq);
-//
-//        // Then
-//        verify(customerRepository).findById(customerId);
-//        verify(accountRepository).save(any(Account.class));
-//        verify(accountAuthService).checkAccount(any(CheckAccountReq.class));
-//
-//    }
-//
-//    @DisplayName("계좌를 수정한다.")
-//    @Test
-//    void updateAccount_Success() {
-//        // Given
-//        Long accountId = 1L;
-//        UpdateAccountReq updateAccountReq = new UpdateAccountReq("1234567890", "004");
-//        Account account = Account.builder().accountNumber("0987654321").bankCode("003").build();
-//        ReflectionTestUtils.setField(account, "id", accountId);
-//
-//        when(accountRepository.findById(accountId)).thenReturn(Optional.of(account));
-//        when(accountAuthService.checkAccount(any(CheckAccountReq.class))).thenReturn(any(CheckAccountRes.class));
-//
-//        // When
-//        accountService.updateAccount(accountId, updateAccountReq);
-//
-//        // Then
-//        assertThat(account.getAccountNumber()).isEqualTo("1234567890");
-//        assertThat(account.getBankCode()).isEqualTo("004");
-//        verify(accountRepository).findById(accountId);
-//        verify(accountAuthService).checkAccount(any(CheckAccountReq.class));
-//    }
-//
-//    @DisplayName("존재하지않는 계좌라면 예외를 발생시킨다.")
-//    @Test
-//    void updateAccount_Fail_AccountNotFound() {
-//        // Given
-//        Long accountId = 1L;
-//        UpdateAccountReq updateAccountReq = new UpdateAccountReq("1234567890", "004");
-//
-//        when(accountRepository.findById(accountId)).thenReturn(Optional.empty());
-//
-//        // When & Then
-//        assertThatThrownBy(() -> accountService.updateAccount(accountId, updateAccountReq))
-//                .isInstanceOf(BadRequestException.class);
-//    }
-//
-//    @DisplayName("계좌를 삭제한다.")
-//    @Test
-//    void deleteAccount_Success() {
-//        // Given
-//        Long accountId = 1L;
-//        Account account = Account.builder().accountNumber("0987654321").bankCode("003").build();
-//        ReflectionTestUtils.setField(account, "id", accountId);
-//
-//        when(accountRepository.findById(accountId)).thenReturn(Optional.of(account));
-//
-//        // When
-//        accountService.deleteAccount(accountId);
-//
-//        // Then
-//        verify(accountRepository).findById(accountId);
-//        verify(accountRepository).delete(account);
-//    }
-//
-//    @DisplayName("존재하지않는 계좌라면 예외를 발생시킨다.")
-//    @Test
-//    void deleteAccount_Fail_AccountNotFound() {
-//        // Given
-//        Long accountId = 1L;
-//
-//        when(accountRepository.findById(accountId)).thenReturn(Optional.empty());
-//
-//        // When & Then
-//        assertThatThrownBy(() -> accountService.deleteAccount(accountId))
-//                .isInstanceOf(BadRequestException.class);
-//    }
-//
-//}
+package shop.sellution.server.account.application;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.*;
+import org.springframework.test.util.ReflectionTestUtils;
+import shop.sellution.server.account.domain.Account;
+import shop.sellution.server.account.domain.AccountRepository;
+import shop.sellution.server.account.domain.type.BankCode;
+import shop.sellution.server.account.dto.request.CheckAccountReq;
+import shop.sellution.server.account.dto.request.SaveAccountReq;
+import shop.sellution.server.account.dto.request.UpdateAccountReq;
+import shop.sellution.server.account.dto.response.CheckAccountRes;
+import shop.sellution.server.account.dto.response.FindAccountRes;
+import shop.sellution.server.account.infrastructure.AccountAuthService;
+import shop.sellution.server.customer.domain.Customer;
+import shop.sellution.server.customer.domain.CustomerRepository;
+import shop.sellution.server.global.exception.BadRequestException;
+import shop.sellution.server.global.type.DisplayStatus;
+import shop.sellution.server.global.util.JasyptEncryptionUtil;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AccountServiceImplTest {
+
+    @Mock
+    private AccountRepository accountRepository;
+
+    @Mock
+    private CustomerRepository customerRepository;
+
+    @Mock
+    private AccountAuthService accountAuthService;
+
+    @Mock
+    private JasyptEncryptionUtil jasyptEncryptionUtil;
+
+    @InjectMocks
+    private AccountServiceImpl accountService;
+
+    @DisplayName("계좌 목록을 조회한다")
+    @Test
+    void findAllAccountsByCustomerId_Success() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
+        Customer customer = Customer.builder().build();
+        ReflectionTestUtils.setField(customer, "id", 1L);
+
+        List<Account> accounts = List.of(
+                Account.builder().accountNumber("encrypted427502039102").bankCode(BankCode.KB.getBackCode()).customer(customer).build(),
+                Account.builder().accountNumber("encrypted3333089607493").bankCode(BankCode.KAKAO.getBackCode()).customer(customer).build()
+        );
+        Page<Account> accountPage = new PageImpl<>(accounts, pageable, accounts.size());
+
+        when(accountRepository.findAllByCustomerId(1L, pageable)).thenReturn(accountPage);
+        when(jasyptEncryptionUtil.decrypt(anyString())).thenAnswer(invocation -> {
+            String input = invocation.getArgument(0);
+            return input.replace("encrypted", "");
+        });
+
+        // when
+        Page<FindAccountRes> result = accountService.findAllAccountsByCustomerId(1L, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent().get(0).getAccountNumber()).isEqualTo("********9102");
+        assertThat(result.getContent().get(1).getAccountNumber()).isEqualTo("*********7493");
+        assertThat(result.getTotalElements()).isEqualTo(2);
+
+        verify(accountRepository).findAllByCustomerId(1L, pageable);
+        verify(jasyptEncryptionUtil, times(2)).decrypt(anyString());
+    }
+
+    @DisplayName("계좌를 생성한다.")
+    @Test
+    void saveAccount_Success() {
+        // Given
+        Long customerId = 1L;
+        SaveAccountReq saveAccountReq = SaveAccountReq.builder().build();
+        saveAccountReq.setAccountNumber("42750204039102");
+        saveAccountReq.setBankCode("004");
+
+        Customer customer = Customer.builder().build();
+        ReflectionTestUtils.setField(customer, "id", 1L);
+
+        CheckAccountRes checkAccountRes = new CheckAccountRes("Test User");
+        when(customerRepository.findById(customerId)).thenReturn(Optional.of(customer));
+        when(accountAuthService.checkAccount(any(CheckAccountReq.class))).thenReturn(checkAccountRes);
+        when(jasyptEncryptionUtil.encrypt(anyString())).thenReturn("encryptedAccountNumber");
+
+        // When
+        accountService.saveAccount(customerId, saveAccountReq);
+
+        // Then
+        verify(customerRepository).findById(customerId);
+        verify(accountRepository).save(any(Account.class));
+        verify(accountAuthService).checkAccount(any(CheckAccountReq.class));
+
+    }
+
+    @DisplayName("계좌를 수정한다.")
+    @Test
+    void updateAccount_Success() {
+        // Given
+        Long accountId = 1L;
+        String originalAccountNumber = "427502039102";
+        String newAccountNumber = "123456789012";
+        UpdateAccountReq updateAccountReq = new UpdateAccountReq(newAccountNumber, "004");
+        Customer customer = Customer.builder().build();
+        ReflectionTestUtils.setField(customer, "id", 1L);
+        Account account = Account.builder()
+                .accountNumber(originalAccountNumber)
+                .bankCode("003")
+                .customer(customer)
+                .build();
+        ReflectionTestUtils.setField(account, "id", accountId);
+
+        when(accountRepository.findById(accountId)).thenReturn(Optional.of(account));
+        when(accountRepository.findAccountByAccountHash(anyLong(), anyString())).thenReturn(Optional.empty());
+        when(accountAuthService.checkAccount(any(CheckAccountReq.class))).thenReturn(CheckAccountRes.builder().build());
+
+        // 암호화 로직을 모방합니다. 실제 구현에서는 앞 8자리만 암호화하고 뒤 4자리는 그대로 붙입니다.
+        when(jasyptEncryptionUtil.encrypt(newAccountNumber.substring(0, newAccountNumber.length() - 4)))
+                .thenReturn("encrypted12345678");
+
+        // When
+        accountService.updateAccount(accountId, updateAccountReq);
+
+        // Then
+        // 예상되는 결과: 암호화된 앞 8자리 + 원래 뒤 4자리
+        String expectedEncryptedNumber = "encrypted12345678" + newAccountNumber.substring(newAccountNumber.length() - 4);
+        assertThat(account.getAccountNumber()).isEqualTo(expectedEncryptedNumber);
+        assertThat(account.getBankCode()).isEqualTo("004");
+
+        verify(accountRepository).findById(accountId);
+        verify(accountAuthService).checkAccount(any(CheckAccountReq.class));
+        verify(jasyptEncryptionUtil).encrypt(newAccountNumber.substring(0, newAccountNumber.length() - 4));
+    }
+
+    @DisplayName("존재하지않는 계좌라면 예외를 발생시킨다.")
+    @Test
+    void updateAccount_Fail_AccountNotFound() {
+        // Given
+        Long accountId = 1L;
+        UpdateAccountReq updateAccountReq = new UpdateAccountReq("1234567890", "004");
+
+        when(accountRepository.findById(accountId)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> accountService.updateAccount(accountId, updateAccountReq))
+                .isInstanceOf(BadRequestException.class);
+    }
+
+    @DisplayName("계좌를 삭제한다.")
+    @Test
+    void deleteAccount_Success() {
+        // Given
+        Long accountId = 1L;
+        Customer customer = Customer.builder().build();
+        ReflectionTestUtils.setField(customer, "id", 1L);
+        Account account = Account.builder()
+                .accountNumber("0987654321")
+                .bankCode("003")
+                .customer(customer)
+                .accountHash("dummyHash")
+                .build();
+        ReflectionTestUtils.setField(account, "id", accountId);
+
+        when(accountRepository.findById(accountId)).thenReturn(Optional.of(account));
+        when(accountRepository.findAccountByAccountHash(anyLong(), anyString())).thenReturn(Optional.empty());
+
+        // When
+        accountService.deleteAccount(accountId);
+
+        // Then
+        verify(accountRepository).findById(accountId);
+        verify(accountRepository).findAccountByAccountHash(eq(1L), eq("dummyHash"));
+        assertThat(account.getIsDeleted()).isEqualTo(DisplayStatus.Y);
+    }
+
+    @DisplayName("존재하지않는 계좌라면 예외를 발생시킨다.")
+    @Test
+    void deleteAccount_Fail_AccountNotFound() {
+        // Given
+        Long accountId = 1L;
+
+        when(accountRepository.findById(accountId)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> accountService.deleteAccount(accountId))
+                .isInstanceOf(BadRequestException.class);
+    }
+
+}

--- a/backend/server/src/test/java/shop/sellution/server/account/presentation/AccountControllerTest.java
+++ b/backend/server/src/test/java/shop/sellution/server/account/presentation/AccountControllerTest.java
@@ -1,207 +1,209 @@
-//package shop.sellution.server.account.presentation;
-//
-//
-//import com.fasterxml.jackson.databind.ObjectMapper;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-//import org.springframework.boot.test.mock.mockito.MockBean;
-//import org.springframework.data.domain.*;
-//import org.springframework.http.MediaType;
-//import org.springframework.restdocs.payload.JsonFieldType;
-//import shop.sellution.server.account.application.AccountServiceImpl;
-//import shop.sellution.server.account.domain.type.BankCode;
-//import shop.sellution.server.account.dto.request.SaveAccountReq;
-//import shop.sellution.server.account.dto.request.UpdateAccountReq;
-//import shop.sellution.server.account.dto.response.FindAccountRes;
-//import shop.sellution.server.common.BaseControllerTest;
-//
-//import java.time.LocalDateTime;
-//import java.util.List;
-//
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.ArgumentMatchers.anyLong;
-//import static org.mockito.Mockito.doNothing;
-//import static org.mockito.Mockito.when;
-//
-//import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-//import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
-//import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
-//import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-//import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-//import static org.springframework.restdocs.request.RequestDocumentation.*;
-//
-//import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-//
-//@WebMvcTest(AccountController.class)
-//class AccountControllerTest extends BaseControllerTest {
-//
-//    @MockBean
-//    private AccountServiceImpl accountService;
-//
-//    @DisplayName("고객 ID로 계좌 목록을 조회한다")
-//    @Test
-//    void findAllAccountsByCustomerId_Success() throws Exception {
-//        // given
-//        Pageable pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
-//
-//        List<FindAccountRes> accounts = List.of(
-//                FindAccountRes.builder()
-//                        .accountId(1L)
-//                        .customerId(1L)
-//                        .bankCode(BankCode.KB.getBackCode())
-//                        .accountNumber("42750204039102")
-//                        .createdAt(LocalDateTime.now())
-//                        .build(),
-//                FindAccountRes.builder()
-//                        .accountId(2L)
-//                        .customerId(1L)
-//                        .bankCode(BankCode.KAKAO.getBackCode())
-//                        .accountNumber("42750204039103")
-//                        .createdAt(LocalDateTime.now())
-//                        .build()
-//        );
-//        Page<FindAccountRes> accountPage = new PageImpl<>(accounts, pageable, accounts.size());
-//
-//        when(accountService.findAllAccountsByCustomerId(1L, pageable)).thenReturn(accountPage);
-//
-//        // when & then
-//        mockMvc.perform(get("/accounts/customers/{customerId}", 1L)
-//                        .param("page", "0")
-//                        .param("size", "10"))
-//                .andExpect(status().isOk())
-//                .andExpect(jsonPath("$.content.length()").value(2))
-//                .andExpect(jsonPath("$.content[0].accountNumber").value("42750204039102"))
-//                .andExpect(jsonPath("$.content[1].accountNumber").value("42750204039103"))
-//                .andDo(document("Account/findAllByCustomerId",
-//                        preprocessRequest(prettyPrint()),
-//                        preprocessResponse(prettyPrint()),
-//                        pathParameters(
-//                                parameterWithName("customerId").description("고객 ID")
-//                        ),
-//                        queryParameters(
-//                                parameterWithName("page").description("페이지 번호 (0부터 시작)").optional(),
-//                                parameterWithName("size").description("페이지 크기").optional()
-//                        ),
-//                        responseFields(
-//                                fieldWithPath("content").type(JsonFieldType.ARRAY).description("계좌 목록"),
-//                                fieldWithPath("content[].accountId").type(JsonFieldType.NUMBER).description("계좌 ID"),
-//                                fieldWithPath("content[].customerId").type(JsonFieldType.NUMBER).description("고객 ID"),
-//                                fieldWithPath("content[].accountNumber").type(JsonFieldType.STRING).description("계좌 번호"),
-//                                fieldWithPath("content[].bankCode").type(JsonFieldType.STRING).description("은행 코드"),
-//                                fieldWithPath("content[].createdAt").type(JsonFieldType.STRING).description("생성 일시").optional(),
-//                                fieldWithPath("pageable").type(JsonFieldType.OBJECT).description("페이지 정보"),
-//                                fieldWithPath("pageable.sort").type(JsonFieldType.OBJECT).description("정렬 정보"),
-//                                fieldWithPath("pageable.sort.empty").type(JsonFieldType.BOOLEAN).description("정렬 정보가 비어있는지 여부"),
-//                                fieldWithPath("pageable.sort.sorted").type(JsonFieldType.BOOLEAN).description("정렬되었는지 여부"),
-//                                fieldWithPath("pageable.sort.unsorted").type(JsonFieldType.BOOLEAN).description("정렬되지 않았는지 여부"),
-//                                fieldWithPath("pageable.pageNumber").type(JsonFieldType.NUMBER).description("페이지 번호"),
-//                                fieldWithPath("pageable.pageSize").type(JsonFieldType.NUMBER).description("페이지 크기"),
-//                                fieldWithPath("pageable.offset").type(JsonFieldType.NUMBER).description("오프셋"),
-//                                fieldWithPath("pageable.paged").type(JsonFieldType.BOOLEAN).description("페이지된 여부"),
-//                                fieldWithPath("pageable.unpaged").type(JsonFieldType.BOOLEAN).description("페이지되지 않은 여부"),
-//                                fieldWithPath("totalPages").type(JsonFieldType.NUMBER).description("전체 페이지 수"),
-//                                fieldWithPath("totalElements").type(JsonFieldType.NUMBER).description("전체 요소 수"),
-//                                fieldWithPath("last").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부"),
-//                                fieldWithPath("size").type(JsonFieldType.NUMBER).description("페이지 크기"),
-//                                fieldWithPath("number").type(JsonFieldType.NUMBER).description("현재 페이지 번호"),
-//                                fieldWithPath("sort").type(JsonFieldType.OBJECT).description("정렬 정보"),
-//                                fieldWithPath("sort.empty").type(JsonFieldType.BOOLEAN).description("정렬 정보가 비어있는지 여부"),
-//                                fieldWithPath("sort.sorted").type(JsonFieldType.BOOLEAN).description("정렬되었는지 여부"),
-//                                fieldWithPath("sort.unsorted").type(JsonFieldType.BOOLEAN).description("정렬되지 않았는지 여부"),
-//                                fieldWithPath("numberOfElements").type(JsonFieldType.NUMBER).description("현재 페이지의 요소 수"),
-//                                fieldWithPath("first").type(JsonFieldType.BOOLEAN).description("첫 페이지 여부"),
-//                                fieldWithPath("empty").type(JsonFieldType.BOOLEAN).description("결과가 비어있는지 여부")
-//                        )
-//                ));
-//    }
-//
-//    @DisplayName("계좌를 저장한다.")
-//    @Test
-//    void saveAccount_Success() throws Exception {
-//        // given
-//        Long customerId = 1L;
-//        SaveAccountReq saveAccountReq = new SaveAccountReq();
-//        saveAccountReq.setAccountNumber("42750204039102");
-//        saveAccountReq.setBankCode("004");
-//
-//        String requestBody = new ObjectMapper().writeValueAsString(saveAccountReq);
-//        // when
-//        doNothing().when(accountService).saveAccount(anyLong(),any(SaveAccountReq.class));
-//
-//        // then
-//        mockMvc.perform(post("/accounts/customers/{customerId}", customerId)
-//                .contentType(MediaType.APPLICATION_JSON)
-//                .content(requestBody))
-//                .andExpect(status().isOk())
-//                .andExpect(content().string("success"))
-//                .andDo(document("Account/saveAccount",
-//                        preprocessRequest(prettyPrint()),
-//                        preprocessResponse(prettyPrint()),
-//                        pathParameters(
-//                                parameterWithName("customerId").description("고객 ID")
-//                        ),
-//                        requestFields(
-//                                fieldWithPath("accountNumber").description("계좌 번호"),
-//                                fieldWithPath("bankCode").description("은행 코드")
-//                        ),
-//                        responseBody()
-//                ));
-//
-//
-//    }
-//
-//    @DisplayName("계좌를 수정한다.")
-//    @Test
-//    void updateAccount_Success() throws Exception {
-//        // given
-//        Long accountId = 1L;
-//        UpdateAccountReq updateAccountReq = new UpdateAccountReq("1234567890", "004");
-//
-//        String requestBody = new ObjectMapper().writeValueAsString(updateAccountReq);
-//
-//        doNothing().when(accountService).updateAccount(anyLong(), any(UpdateAccountReq.class));
-//
-//        // when & then
-//        mockMvc.perform(put("/accounts/{accountId}", accountId)
-//                        .contentType(MediaType.APPLICATION_JSON)
-//                        .content(requestBody))
-//                .andExpect(status().isOk())
-//                .andExpect(content().string("success"))
-//                .andDo(document("Account/updateAccount",
-//                        preprocessRequest(prettyPrint()),
-//                        preprocessResponse(prettyPrint()),
-//                        pathParameters(
-//                                parameterWithName("accountId").description("계좌 ID")
-//                        ),
-//                        requestFields(
-//                                fieldWithPath("accountNumber").type(JsonFieldType.STRING).description("계좌 번호"),
-//                                fieldWithPath("bankCode").type(JsonFieldType.STRING).description("은행 코드")
-//                        )
-//                ));
-//    }
-//
-//    @DisplayName("계좌를 삭제한다.")
-//    @Test
-//    void deleteAccount_Success() throws Exception {
-//        // given
-//        Long accountId = 1L;
-//
-//        doNothing().when(accountService).deleteAccount(anyLong());
-//
-//        // when & then
-//        mockMvc.perform(delete("/accounts/{accountId}", accountId))
-//                .andExpect(status().isOk())
-//                .andExpect(content().string("success"))
-//                .andDo(document("Account/deleteAccount",
-//                        preprocessRequest(prettyPrint()),
-//                        preprocessResponse(prettyPrint()),
-//                        pathParameters(
-//                                parameterWithName("accountId").description("계좌 ID")
-//                        )
-//                ));
-//    }
-//
-//
-//
-//}
+package shop.sellution.server.account.presentation;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.*;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import shop.sellution.server.account.application.AccountServiceImpl;
+import shop.sellution.server.account.domain.type.BankCode;
+import shop.sellution.server.account.dto.request.SaveAccountReq;
+import shop.sellution.server.account.dto.request.UpdateAccountReq;
+import shop.sellution.server.account.dto.response.FindAccountRes;
+import shop.sellution.server.common.BaseControllerTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AccountController.class)
+class AccountControllerTest extends BaseControllerTest {
+
+    @MockBean
+    private AccountServiceImpl accountService;
+
+    @DisplayName("고객 ID로 계좌 목록을 조회한다")
+    @Test
+    void findAllAccountsByCustomerId_Success() throws Exception {
+        // given
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
+
+        List<FindAccountRes> accounts = List.of(
+                FindAccountRes.builder()
+                        .accountId(1L)
+                        .customerId(1L)
+                        .bankCode(BankCode.KB.getBackCode())
+                        .accountNumber("42750204039102")
+                        .createdAt(LocalDateTime.now())
+                        .build(),
+                FindAccountRes.builder()
+                        .accountId(2L)
+                        .customerId(1L)
+                        .bankCode(BankCode.KAKAO.getBackCode())
+                        .accountNumber("42750204039103")
+                        .createdAt(LocalDateTime.now())
+                        .build()
+        );
+        Page<FindAccountRes> accountPage = new PageImpl<>(accounts, pageable, accounts.size());
+
+        when(accountService.findAllAccountsByCustomerId(1L, pageable)).thenReturn(accountPage);
+
+        // when & then
+        mockMvc.perform(get("/accounts/customers/{customerId}", 1L)
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(2))
+                .andExpect(jsonPath("$.content[0].accountNumber").value("42750204039102"))
+                .andExpect(jsonPath("$.content[1].accountNumber").value("42750204039103"))
+                .andDo(document("Account/findAllByCustomerId",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("customerId").description("고객 ID")
+                        ),
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호 (0부터 시작)").optional(),
+                                parameterWithName("size").description("페이지 크기").optional()
+                        ),
+                        responseFields(
+                                fieldWithPath("content").type(JsonFieldType.ARRAY).description("계좌 목록"),
+                                fieldWithPath("content[].accountId").type(JsonFieldType.NUMBER).description("계좌 ID"),
+                                fieldWithPath("content[].customerId").type(JsonFieldType.NUMBER).description("고객 ID"),
+                                fieldWithPath("content[].accountNumber").type(JsonFieldType.STRING).description("계좌 번호"),
+                                fieldWithPath("content[].bankCode").type(JsonFieldType.STRING).description("은행 코드"),
+                                fieldWithPath("content[].createdAt").type(JsonFieldType.STRING).description("생성 일시").optional(),
+                                fieldWithPath("pageable").type(JsonFieldType.OBJECT).description("페이지 정보"),
+                                fieldWithPath("pageable.sort").type(JsonFieldType.OBJECT).description("정렬 정보"),
+                                fieldWithPath("pageable.sort.empty").type(JsonFieldType.BOOLEAN).description("정렬 정보가 비어있는지 여부"),
+                                fieldWithPath("pageable.sort.sorted").type(JsonFieldType.BOOLEAN).description("정렬되었는지 여부"),
+                                fieldWithPath("pageable.sort.unsorted").type(JsonFieldType.BOOLEAN).description("정렬되지 않았는지 여부"),
+                                fieldWithPath("pageable.pageNumber").type(JsonFieldType.NUMBER).description("페이지 번호"),
+                                fieldWithPath("pageable.pageSize").type(JsonFieldType.NUMBER).description("페이지 크기"),
+                                fieldWithPath("pageable.offset").type(JsonFieldType.NUMBER).description("오프셋"),
+                                fieldWithPath("pageable.paged").type(JsonFieldType.BOOLEAN).description("페이지된 여부"),
+                                fieldWithPath("pageable.unpaged").type(JsonFieldType.BOOLEAN).description("페이지되지 않은 여부"),
+                                fieldWithPath("totalPages").type(JsonFieldType.NUMBER).description("전체 페이지 수"),
+                                fieldWithPath("totalElements").type(JsonFieldType.NUMBER).description("전체 요소 수"),
+                                fieldWithPath("last").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부"),
+                                fieldWithPath("size").type(JsonFieldType.NUMBER).description("페이지 크기"),
+                                fieldWithPath("number").type(JsonFieldType.NUMBER).description("현재 페이지 번호"),
+                                fieldWithPath("sort").type(JsonFieldType.OBJECT).description("정렬 정보"),
+                                fieldWithPath("sort.empty").type(JsonFieldType.BOOLEAN).description("정렬 정보가 비어있는지 여부"),
+                                fieldWithPath("sort.sorted").type(JsonFieldType.BOOLEAN).description("정렬되었는지 여부"),
+                                fieldWithPath("sort.unsorted").type(JsonFieldType.BOOLEAN).description("정렬되지 않았는지 여부"),
+                                fieldWithPath("numberOfElements").type(JsonFieldType.NUMBER).description("현재 페이지의 요소 수"),
+                                fieldWithPath("first").type(JsonFieldType.BOOLEAN).description("첫 페이지 여부"),
+                                fieldWithPath("empty").type(JsonFieldType.BOOLEAN).description("결과가 비어있는지 여부")
+                        )
+                ));
+    }
+
+    @DisplayName("계좌를 저장한다.")
+    @Test
+    void saveAccount_Success() throws Exception {
+        // given
+        Long customerId = 1L;
+        Long expectedAccountId = 100L;
+        SaveAccountReq saveAccountReq = SaveAccountReq.builder()
+                .accountNumber("42750204039102")
+                .bankCode("004")
+                .build();
+
+        when(accountService.saveAccount(eq(customerId), any(SaveAccountReq.class)))
+                .thenReturn(expectedAccountId);
+
+        // when & then
+        mockMvc.perform(post("/accounts/customers/{customerId}", customerId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(saveAccountReq)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.TEXT_PLAIN + ";charset=UTF-8"))
+                .andExpect(content().string("success id : " + expectedAccountId))
+                .andDo(document("Account/saveAccount",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("customerId").description("고객 ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("accountNumber").description("계좌 번호"),
+                                fieldWithPath("bankCode").description("은행 코드")
+                        ),
+                        responseBody()
+                ));
+
+        // verify
+        verify(accountService).saveAccount(eq(customerId), any(SaveAccountReq.class));
+    }
+
+    @DisplayName("계좌를 수정한다.")
+    @Test
+    void updateAccount_Success() throws Exception {
+        // given
+        Long accountId = 1L;
+        UpdateAccountReq updateAccountReq = new UpdateAccountReq("1234567890", "004");
+
+        String requestBody = new ObjectMapper().writeValueAsString(updateAccountReq);
+
+        doNothing().when(accountService).updateAccount(anyLong(), any(UpdateAccountReq.class));
+
+        // when & then
+        mockMvc.perform(put("/accounts/{accountId}", accountId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(content().string("success"))
+                .andDo(document("Account/updateAccount",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("accountId").description("계좌 ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("accountNumber").type(JsonFieldType.STRING).description("계좌 번호"),
+                                fieldWithPath("bankCode").type(JsonFieldType.STRING).description("은행 코드")
+                        )
+                ));
+    }
+
+    @DisplayName("계좌를 삭제한다.")
+    @Test
+    void deleteAccount_Success() throws Exception {
+        // given
+        Long accountId = 1L;
+
+        doNothing().when(accountService).deleteAccount(anyLong());
+
+        // when & then
+        mockMvc.perform(delete("/accounts/{accountId}", accountId))
+                .andExpect(status().isOk())
+                .andExpect(content().string("success"))
+                .andDo(document("Account/deleteAccount",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("accountId").description("계좌 ID")
+                        )
+                ));
+    }
+
+
+
+}

--- a/backend/server/src/test/java/shop/sellution/server/order/application/OrderServiceImplTest.java
+++ b/backend/server/src/test/java/shop/sellution/server/order/application/OrderServiceImplTest.java
@@ -1,296 +1,398 @@
-//package shop.sellution.server.order.application;
-//
-//
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//import org.springframework.data.domain.*;
-//import org.springframework.test.util.ReflectionTestUtils;
-//import shop.sellution.server.account.domain.Account;
-//import shop.sellution.server.address.domain.Address;
-//import shop.sellution.server.company.domain.Company;
-//import shop.sellution.server.company.domain.repository.CompanyRepository;
-//import shop.sellution.server.customer.domain.Customer;
-//import shop.sellution.server.customer.domain.CustomerRepository;
-//import shop.sellution.server.global.exception.BadRequestException;
-//import shop.sellution.server.global.type.DisplayStatus;
-//import shop.sellution.server.order.domain.Order;
-//import shop.sellution.server.order.domain.repository.OrderRepository;
-//import shop.sellution.server.order.domain.repository.OrderedProductRepository;
-//import shop.sellution.server.order.domain.type.DeliveryStatus;
-//import shop.sellution.server.order.domain.type.OrderStatus;
-//import shop.sellution.server.order.dto.OrderSearchCondition;
-//import shop.sellution.server.order.dto.request.CancelOrderReq;
-//import shop.sellution.server.order.dto.response.FindOrderRes;
-//import shop.sellution.server.payment.application.PaymentCancelService;
-//import shop.sellution.server.payment.application.PaymentService;
-//import shop.sellution.server.payment.domain.PaymentHistory;
-//import shop.sellution.server.payment.domain.repository.PaymentHistoryRepository;
-//import shop.sellution.server.product.domain.ProductImageRepository;
-//
-//import java.util.ArrayList;
-//import java.util.Collections;
-//import java.util.List;
-//import java.util.Optional;
-//
-//import static org.assertj.core.api.Assertions.assertThat;
-//import static org.assertj.core.api.Assertions.assertThatThrownBy;
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.Mockito.*;
-//
-//@ExtendWith(MockitoExtension.class)
-//class OrderServiceImplTest {
-//
-//    @Mock
-//    private OrderRepository orderRepository;
-//
-//    @Mock
-//    private CompanyRepository companyRepository;
-//
-//    @Mock
-//    private PaymentCancelService paymentCancelService;
-//
-//    @Mock
-//    private PaymentHistoryRepository paymentHistoryRepository;
-//
-//    @Mock
-//    private PaymentService paymentService;
-//
-//    @Mock
-//    private OrderedProductRepository orderedProductRepository;
-//
-//    @Mock
-//    private ProductImageRepository productImageRepository;
-//
-//    @Mock
-//    private CustomerRepository customerRepository;
-//
-//    @InjectMocks
-//    private OrderServiceImpl orderService;
-//
-//    @Test
-//    @DisplayName("고객 ID로 주문 목록을 조회한다")
-//    void findAllOrderByCustomerId() {
-//        // Given
-//        Long customerId = 1L;
-//        Pageable pageable = PageRequest.of(0, 10);
-//
-//        Customer mockCustomer = mock(Customer.class);
-//        lenient().when(mockCustomer.getId()).thenReturn(customerId);
-//        lenient().when(mockCustomer.getName()).thenReturn("Test Customer");
-//        lenient().when(mockCustomer.getPhoneNumber()).thenReturn("010-1234-5678");
-//
-//        Address mockAddress = mock(Address.class);
-//        lenient().when(mockAddress.getId()).thenReturn(1L);
-//        lenient().when(mockAddress.getAddress()).thenReturn("Test Address");
-//
-//        Order mockOrder = mock(Order.class);
-//        lenient().when(mockOrder.getId()).thenReturn(1L);
-//        lenient().when(mockOrder.getCustomer()).thenReturn(mockCustomer);
-//        lenient().when(mockOrder.getAddress()).thenReturn(mockAddress);
-//        lenient().when(mockOrder.getOrderedProducts()).thenReturn(new ArrayList<>());
-//        lenient().when(mockOrder.getSelectedDays()).thenReturn(new ArrayList<>());
-//
-//        List<Order> orderList = List.of(mockOrder);
-//        Page<Order> orderPage = new PageImpl<>(orderList, pageable, orderList.size());
-//
-//        when(orderRepository.findAllOrderByCustomerId(customerId, pageable)).thenReturn(orderPage);
-//        when(orderedProductRepository.findAllByOrderIdIn(any())).thenReturn(Collections.emptyList());
-//        when(productImageRepository.findAllByProductIdIn(any())).thenReturn(Collections.emptyList());
-//
-//        // When
-//        Page<FindOrderRes> result = orderService.findAllOrderByCustomerId(customerId, pageable);
-//
-//        // Then
-//        assertThat(result).isNotNull();
-//        assertThat(result.getTotalElements()).isEqualTo(1);
-//        FindOrderRes orderRes = result.getContent().get(0);
-//        assertThat(orderRes.getCustomer()).isNotNull();
-//        assertThat(orderRes.getCustomer().getId()).isEqualTo(customerId);
-//        assertThat(orderRes.getAddress()).isNotNull();
-//        verify(orderRepository).findAllOrderByCustomerId(customerId, pageable);
-//        verify(orderedProductRepository).findAllByOrderIdIn(any());
-//        verify(productImageRepository).findAllByProductIdIn(any());
-//    }
-//
-//    @DisplayName("회사 ID로 주문 목록을 조회한다")
-//    @Test
-//    void findAllOrderByCompanyId_Success() {
-//        // given
-//        Long companyId = 1L;
-//        OrderSearchCondition condition = OrderSearchCondition.builder().build();
-//        Pageable pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
-//
-//        Customer customer = Customer.builder()
-//                .id(1L)
-//                .name("Test Customer")
-//                .phoneNumber("010-1234-5678")
-//                .build();
-//
-//        Address address = Address.builder()
-//                .address("Test Address")
-//                .build();
-//        ReflectionTestUtils.setField(address, "id", 1L);
-//
-//
-//        List<Order> orders = List.of(
-//                Order.builder()
-//                        .id(1L)
-//                        .customer(customer)
-//                        .address(address)
-//                        .orderedProducts(new ArrayList<>())
-//                        .selectedDays(new ArrayList<>())
-//                        .build(),
-//                Order.builder()
-//                        .id(2L)
-//                        .customer(customer)
-//                        .address(address)
-//                        .orderedProducts(new ArrayList<>())
-//                        .selectedDays(new ArrayList<>())
-//                        .build()
-//        );
-//        Page<Order> orderPage = new PageImpl<>(orders, pageable, orders.size());
-//
-//        when(orderRepository.findOrderByCompanyIdAndCondition(companyId, condition, pageable)).thenReturn(orderPage);
-//
-//        // when
-//        Page<FindOrderRes> result = orderService.findAllOrderByCompanyId(companyId, condition, pageable);
-//
-//        // then
-//        assertThat(result).isNotNull();
-//        assertThat(result.getContent()).hasSize(2);
-//        assertThat(result.getTotalElements()).isEqualTo(2);
-//        assertThat(result.getContent().get(0).getCustomer()).isNotNull();
-//        assertThat(result.getContent().get(0).getCustomer().getId()).isEqualTo(1L);
-//        assertThat(result.getContent().get(0).getAddress()).isNotNull();
-//        assertThat(result.getContent().get(0).getAddress().getAddress()).isEqualTo("Test Address");
-//
-//        verify(orderRepository).findOrderByCompanyIdAndCondition(companyId, condition, pageable);
-//    }
-//
-//    @DisplayName("주문을 승인한다")
-//    @Test
-//    void approveOrder_Success() {
-//        // given
-//        Long orderId = 1L;
-//        Order order = Order.builder().id(orderId).status(OrderStatus.HOLD).build();
-//        Customer customer = Customer.builder().id(1L).build();
-//        Account account = Account.builder().build();
-//        ReflectionTestUtils.setField(account, "id", 1L);
-//        ReflectionTestUtils.setField(order, "customer", customer);
-//        order.setAccount(account);
-//        when(orderRepository.findOrderById(orderId)).thenReturn(Optional.of(order));
-//
-//        // when
-//        orderService.approveOrder(orderId);
-//
-//        // then
-//        assertThat(order.getStatus()).isEqualTo(OrderStatus.APPROVED);
-//        verify(orderRepository).findOrderById(orderId);
-//        verify(paymentService).pay(any());
-//    }
-//
-//    @DisplayName("이미 승인된 주문은 예외를 발생시킨다")
-//    @Test
-//    void approveOrder_Fail_AlreadyApproved() {
-//        // given
-//        Long orderId = 1L;
-//        Order order = Order.builder().id(orderId).status(OrderStatus.APPROVED).build();
-//
-//        when(orderRepository.findOrderById(orderId)).thenReturn(Optional.of(order));
-//
-//        // when & then
-//        assertThatThrownBy(() -> orderService.approveOrder(orderId))
-//                .isInstanceOf(BadRequestException.class);
-//    }
-//
-//    @DisplayName("주문 자동 승인을 토글한다")
-//    @Test
-//    void toggleAutoApprove_Success() {
-//        // given
-//        Long companyId = 1L;
-//        Company company = Company.builder().build();
-//        company.toggleAutoApproval();
-//        ReflectionTestUtils.setField(company, "companyId", 1L);
-//
-//        when(companyRepository.findById(companyId)).thenReturn(Optional.of(company));
-//
-//        // when
-//        orderService.toggleAutoApprove(companyId);
-//
-//        // then
-//        assertThat(company.getIsAutoApproved()).isEqualTo(DisplayStatus.N);
-//        verify(companyRepository).findById(companyId);
-//    }
-//
-//    @DisplayName("주문을 취소한다")
-//    @Test
-//    void cancelOrder_Success() {
-//        // given
-//        Long orderId = 1L;
-//        Long accountId = 1L;
-//        Long customerId = 3L;
-//
-//        Customer customer = Customer.builder().id(customerId).build();
-//        Account account = Account.builder().build();
-//        ReflectionTestUtils.setField(account, "id", 1L);
-//        Order order = Order.builder()
-//                .id(orderId)
-//                .status(OrderStatus.APPROVED)
-//                .account(account)
-//                .deliveryStatus(DeliveryStatus.BEFORE_DELIVERY)
-//                .build();
-//
-//        CancelOrderReq cancelOrderReq = CancelOrderReq.builder()
-//                .customerId(customerId)
-//                .accountId(accountId)
-//                .build();
-//
-//        when(orderRepository.findById(orderId)).thenReturn(Optional.of(order));
-//        when(customerRepository.findById(customerId)).thenReturn(Optional.of(customer));
-//        when(paymentHistoryRepository.findFirstByOrderIdOrderByCreatedAtDesc(orderId)).thenReturn(null);
-//
-//        // when
-//        orderService.cancelOrder(orderId, cancelOrderReq);
-//
-//        // then
-//        assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCEL);
-//        verify(orderRepository).findById(orderId);
-//        verify(customerRepository).findById(customerId);
-//        verify(paymentHistoryRepository).findFirstByOrderIdOrderByCreatedAtDesc(orderId);
-//    }
-//
-//    @DisplayName("주문 ID로 주문을 조회한다")
-//    @Test
-//    void findOrder_Success() {
-//        // Given
-//        Long orderId = 1L;
-//        Address address = Address.builder().address("Test Address").build();
-//        ReflectionTestUtils.setField(address, "id", 1L);
-//        Order order = Order.builder()
-//                .id(orderId)
-//                .customer(Customer.builder().id(1L).name("Test Customer").phoneNumber("010-1234-5678").build())
-//                .address(address)
-//                .orderedProducts(new ArrayList<>())
-//                .selectedDays(new ArrayList<>())
-//                .build();
-//
-//        when(orderRepository.findById(orderId)).thenReturn(Optional.of(order));
-//        when(orderedProductRepository.findAllByOrderIdIn(List.of(orderId))).thenReturn(new ArrayList<>());
-//        when(productImageRepository.findAllByProductIdIn(any())).thenReturn(new ArrayList<>());
-//
-//        // When
-//        FindOrderRes result = orderService.findOrder(orderId);
-//
-//        // Then
-//        assertThat(result).isNotNull();
-//        assertThat(result.getCustomer().getId()).isEqualTo(1L);
-//        assertThat(result.getAddress().getId()).isEqualTo(1L);
-//        verify(orderRepository).findById(orderId);
-//        verify(orderedProductRepository).findAllByOrderIdIn(List.of(orderId));
-//        verify(productImageRepository).findAllByProductIdIn(any());
-//    }
-//}
+package shop.sellution.server.order.application;
+
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.*;
+import org.springframework.test.util.ReflectionTestUtils;
+import shop.sellution.server.account.domain.Account;
+import shop.sellution.server.address.domain.Address;
+import shop.sellution.server.company.domain.Company;
+import shop.sellution.server.company.domain.repository.CompanyRepository;
+import shop.sellution.server.customer.domain.Customer;
+import shop.sellution.server.customer.domain.CustomerRepository;
+import shop.sellution.server.global.exception.BadRequestException;
+import shop.sellution.server.global.type.DisplayStatus;
+import shop.sellution.server.order.domain.Order;
+import shop.sellution.server.order.domain.OrderedProduct;
+import shop.sellution.server.order.domain.repository.OrderRepository;
+import shop.sellution.server.order.domain.repository.OrderedProductRepository;
+import shop.sellution.server.order.domain.type.DeliveryStatus;
+import shop.sellution.server.order.domain.type.OrderStatus;
+import shop.sellution.server.order.dto.OrderSearchCondition;
+import shop.sellution.server.order.dto.request.CancelOrderReq;
+import shop.sellution.server.order.dto.response.FindOrderRes;
+import shop.sellution.server.payment.application.PaymentCancelService;
+import shop.sellution.server.payment.application.PaymentService;
+import shop.sellution.server.payment.domain.PaymentHistory;
+import shop.sellution.server.payment.domain.repository.PaymentHistoryRepository;
+import shop.sellution.server.product.domain.Product;
+import shop.sellution.server.product.domain.ProductImageRepository;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceImplTest {
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private CompanyRepository companyRepository;
+
+    @Mock
+    private PaymentCancelService paymentCancelService;
+
+    @Mock
+    private PaymentHistoryRepository paymentHistoryRepository;
+
+    @Mock
+    private PaymentService paymentService;
+
+    @Mock
+    private OrderedProductRepository orderedProductRepository;
+
+    @Mock
+    private ProductImageRepository productImageRepository;
+
+    @Mock
+    private CustomerRepository customerRepository;
+
+    @InjectMocks
+    private OrderServiceImpl orderService;
+
+    @Test
+    @DisplayName("고객 ID로 주문 목록을 조회한다")
+    void findAllOrderByCustomerId() {
+        // Given
+        Long customerId = 1L;
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Customer mockCustomer = Customer.builder()
+                .id(customerId)
+                .name("Test Customer")
+                .phoneNumber("010-1234-5678")
+                .build();
+
+        Address mockAddress = Address.builder()
+                .address("Test Address")
+                .build();
+        ReflectionTestUtils.setField(mockAddress, "id", 1L);
+
+        Account mockAccount = Account.builder()
+                .build();
+        ReflectionTestUtils.setField(mockAccount, "id", 1L);
+
+        Order mockOrder = Order.builder()
+                .id(1L)
+                .customer(mockCustomer)
+                .address(mockAddress)
+                .account(mockAccount)
+                .orderedProducts(new ArrayList<>())
+                .selectedDays(new ArrayList<>())
+                .build();
+
+        List<Order> orderList = List.of(mockOrder);
+        Page<Order> orderPage = new PageImpl<>(orderList, pageable, orderList.size());
+
+        when(orderRepository.findAllOrderByCustomerId(customerId, pageable)).thenReturn(orderPage);
+        when(orderedProductRepository.findAllByOrderIdIn(any())).thenReturn(Collections.emptyList());
+        when(productImageRepository.findAllByProductIdIn(any())).thenReturn(Collections.emptyList());
+
+        // When
+        Page<FindOrderRes> result = orderService.findAllOrderByCustomerId(customerId, pageable);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        FindOrderRes orderRes = result.getContent().get(0);
+        assertThat(orderRes.getCustomer()).isNotNull();
+        assertThat(orderRes.getCustomer().getId()).isEqualTo(customerId);
+        assertThat(orderRes.getAddress()).isNotNull();
+        assertThat(orderRes.getAccountId()).isEqualTo(1L);
+        verify(orderRepository).findAllOrderByCustomerId(customerId, pageable);
+        verify(orderedProductRepository).findAllByOrderIdIn(any());
+        verify(productImageRepository).findAllByProductIdIn(any());
+    }
+
+    @DisplayName("회사 ID로 주문 목록을 조회한다")
+    @Test
+    void findAllOrderByCompanyId_Success() {
+        // given
+        Long companyId = 1L;
+        OrderSearchCondition condition = OrderSearchCondition.builder().build();
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
+
+        Customer customer = Customer.builder()
+                .id(1L)
+                .name("Test Customer")
+                .phoneNumber("010-1234-5678")
+                .build();
+
+        Address address = Address.builder()
+                .address("Test Address")
+                .build();
+        ReflectionTestUtils.setField(address, "id", 1L);
+
+        Account account = Account.builder().build(); // Account 객체 생성
+        ReflectionTestUtils.setField(account, "id", 1L); // Account ID 설정
+
+        List<Order> orders = List.of(
+                Order.builder()
+                        .id(1L)
+                        .customer(customer)
+                        .address(address)
+                        .account(account) // Account 설정
+                        .orderedProducts(new ArrayList<>())
+                        .selectedDays(new ArrayList<>())
+                        .build(),
+                Order.builder()
+                        .id(2L)
+                        .customer(customer)
+                        .address(address)
+                        .account(account) // Account 설정
+                        .orderedProducts(new ArrayList<>())
+                        .selectedDays(new ArrayList<>())
+                        .build()
+        );
+        Page<Order> orderPage = new PageImpl<>(orders, pageable, orders.size());
+
+        when(orderRepository.findOrderByCompanyIdAndCondition(companyId, condition, pageable)).thenReturn(orderPage);
+        when(orderedProductRepository.findAllByOrderIdIn(anyList())).thenReturn(new ArrayList<>());
+        when(productImageRepository.findAllByProductIdIn(anyList())).thenReturn(new ArrayList<>());
+
+        // when
+        Page<FindOrderRes> result = orderService.findAllOrderByCompanyId(companyId, condition, pageable);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent().get(0).getCustomer()).isNotNull();
+        assertThat(result.getContent().get(0).getCustomer().getId()).isEqualTo(1L);
+        assertThat(result.getContent().get(0).getAddress()).isNotNull();
+        assertThat(result.getContent().get(0).getAddress().getAddress()).isEqualTo("Test Address");
+        assertThat(result.getContent().get(0).getAccountId()).isEqualTo(1L); // Account ID 확인
+
+        verify(orderRepository).findOrderByCompanyIdAndCondition(companyId, condition, pageable);
+        verify(orderedProductRepository).findAllByOrderIdIn(anyList());
+        verify(productImageRepository).findAllByProductIdIn(anyList());
+    }
+
+    @DisplayName("주문을 승인한다")
+    @Test
+    void approveOrder_Success() {
+        // given
+        Long orderId = 1L;
+        Order order = Order.builder().id(orderId).status(OrderStatus.HOLD).build();
+        Customer customer = Customer.builder().id(1L).build();
+        Account account = Account.builder().build();
+        ReflectionTestUtils.setField(account, "id", 1L);
+        ReflectionTestUtils.setField(order, "customer", customer);
+        order.setAccount(account);
+        when(orderRepository.findOrderById(orderId)).thenReturn(Optional.of(order));
+
+        // when
+        orderService.approveOrder(orderId);
+
+        // then
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.APPROVED);
+        verify(orderRepository).findOrderById(orderId);
+        verify(paymentService).pay(any());
+    }
+
+    @DisplayName("이미 승인된 주문은 예외를 발생시킨다")
+    @Test
+    void approveOrder_Fail_AlreadyApproved() {
+        // given
+        Long orderId = 1L;
+        Order order = Order.builder().id(orderId).status(OrderStatus.APPROVED).build();
+
+        when(orderRepository.findOrderById(orderId)).thenReturn(Optional.of(order));
+
+        // when & then
+        assertThatThrownBy(() -> orderService.approveOrder(orderId))
+                .isInstanceOf(BadRequestException.class);
+    }
+
+    @DisplayName("주문 자동 승인을 토글한다")
+    @Test
+    void toggleAutoApprove_Success() {
+        // given
+        Long companyId = 1L;
+        Company company = Company.builder().build();
+        company.toggleAutoApproval();
+        ReflectionTestUtils.setField(company, "companyId", 1L);
+
+        when(companyRepository.findById(companyId)).thenReturn(Optional.of(company));
+
+        // when
+        orderService.toggleAutoApprove(companyId);
+
+        // then
+        assertThat(company.getIsAutoApproved()).isEqualTo(DisplayStatus.N);
+        verify(companyRepository).findById(companyId);
+    }
+
+    @DisplayName("주문을 취소한다")
+    @Test
+    void cancelOrder_Success() {
+        // given
+        Long orderId = 1L;
+        Long accountId = 1L;
+        Long customerId = 3L;
+
+        Customer customer = Customer.builder().id(customerId).build();
+        Account account = Account.builder().build();
+        ReflectionTestUtils.setField(account, "id", 1L);
+        Order order = Order.builder()
+                .id(orderId)
+                .status(OrderStatus.APPROVED)
+                .account(account)
+                .deliveryStatus(DeliveryStatus.BEFORE_DELIVERY)
+                .build();
+
+        CancelOrderReq cancelOrderReq = CancelOrderReq.builder()
+                .customerId(customerId)
+                .accountId(accountId)
+                .build();
+
+        when(orderRepository.findById(orderId)).thenReturn(Optional.of(order));
+        when(customerRepository.findById(customerId)).thenReturn(Optional.of(customer));
+        when(paymentHistoryRepository.findFirstByOrderIdOrderByCreatedAtDesc(orderId)).thenReturn(null);
+
+        // when
+        orderService.cancelOrder(orderId, cancelOrderReq);
+
+        // then
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCEL);
+        verify(orderRepository).findById(orderId);
+        verify(customerRepository).findById(customerId);
+        verify(paymentHistoryRepository).findFirstByOrderIdOrderByCreatedAtDesc(orderId);
+    }
+
+    @DisplayName("주문 ID로 주문을 조회한다")
+    @Test
+    void findOrder_Success() {
+        // Given
+        Long orderId = 1L;
+        Address address = Address.builder().address("Test Address").build();
+        ReflectionTestUtils.setField(address, "id", 1L);
+        Account account = Account.builder().build(); // 계정 객체 생성
+        ReflectionTestUtils.setField(account, "id", 1L); // 계정 ID 설정
+        Order order = Order.builder()
+                .id(orderId)
+                .customer(Customer.builder().id(1L).name("Test Customer").phoneNumber("010-1234-5678").build())
+                .address(address)
+                .account(account) // 계정 설정
+                .orderedProducts(new ArrayList<>())
+                .selectedDays(new ArrayList<>())
+                .build();
+
+        when(orderRepository.findById(orderId)).thenReturn(Optional.of(order));
+        when(orderedProductRepository.findAllByOrderIdIn(List.of(orderId))).thenReturn(new ArrayList<>());
+        when(productImageRepository.findAllByProductIdIn(any())).thenReturn(new ArrayList<>());
+
+        // When
+        FindOrderRes result = orderService.findOrder(orderId);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getCustomer().getId()).isEqualTo(1L);
+        assertThat(result.getAddress().getId()).isEqualTo(1L);
+        assertThat(result.getAccountId()).isEqualTo(1L); // 계정 ID 확인
+        verify(orderRepository).findById(orderId);
+        verify(orderedProductRepository).findAllByOrderIdIn(List.of(orderId));
+        verify(productImageRepository).findAllByProductIdIn(any());
+    }
+
+    @Test
+    @DisplayName("주문한 상품의 재고가 충분한 경우 true를 반환한다")
+    void checkStock_SufficientStock_ReturnsTrue() {
+        // Given
+        Long orderId = 1L;
+        Order mockOrder = mock(Order.class);
+        when(orderRepository.findById(orderId)).thenReturn(Optional.of(mockOrder));
+
+        OrderedProduct orderedProduct1 = mock(OrderedProduct.class);
+        OrderedProduct orderedProduct2 = mock(OrderedProduct.class);
+        List<OrderedProduct> orderedProducts = List.of(orderedProduct1, orderedProduct2);
+
+        Product product1 = mock(Product.class);
+        Product product2 = mock(Product.class);
+
+        when(orderedProductRepository.findAllByOrderIdIn(List.of(orderId))).thenReturn(orderedProducts);
+        when(orderedProduct1.getProduct()).thenReturn(product1);
+        when(orderedProduct2.getProduct()).thenReturn(product2);
+        when(orderedProduct1.getCount()).thenReturn(5);
+        when(orderedProduct2.getCount()).thenReturn(3);
+        when(product1.getStock()).thenReturn(10);
+        when(product2.getStock()).thenReturn(5);
+
+        // When
+        boolean result = orderService.checkStock(orderId);
+
+        // Then
+        assertThat(result).isTrue();
+        verify(orderRepository).findById(orderId);
+        verify(orderedProductRepository).findAllByOrderIdIn(List.of(orderId));
+    }
+
+    @Test
+    @DisplayName("주문한 상품 중 하나라도 재고가 부족한 경우 false를 반환한다")
+    void checkStock_InsufficientStock_ReturnsFalse() {
+        // Given
+        Long orderId = 1L;
+        Order mockOrder = mock(Order.class);
+        when(orderRepository.findById(orderId)).thenReturn(Optional.of(mockOrder));
+
+        OrderedProduct orderedProduct1 = mock(OrderedProduct.class);
+        OrderedProduct orderedProduct2 = mock(OrderedProduct.class);
+        List<OrderedProduct> orderedProducts = List.of(orderedProduct1, orderedProduct2);
+
+        Product product1 = mock(Product.class);
+        Product product2 = mock(Product.class);
+
+        when(orderedProductRepository.findAllByOrderIdIn(List.of(orderId))).thenReturn(orderedProducts);
+        when(orderedProduct1.getProduct()).thenReturn(product1);
+        when(orderedProduct2.getProduct()).thenReturn(product2);
+        when(orderedProduct1.getCount()).thenReturn(5);
+        when(orderedProduct2.getCount()).thenReturn(6);  // 재고 부족
+        when(product1.getStock()).thenReturn(10);
+        when(product2.getStock()).thenReturn(5);  // 재고 부족
+
+        // When
+        boolean result = orderService.checkStock(orderId);
+
+        // Then
+        assertThat(result).isFalse();
+        verify(orderRepository).findById(orderId);
+        verify(orderedProductRepository).findAllByOrderIdIn(List.of(orderId));
+    }
+
+    @Test
+    @DisplayName("주문이 존재하지 않는 경우 예외를 던진다")
+    void checkStock_OrderNotFound_ThrowsException() {
+        // Given
+        Long orderId = 1L;
+        when(orderRepository.findById(orderId)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> orderService.checkStock(orderId))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("NOT_FOUND_ORDER");
+        verify(orderRepository).findById(orderId);
+    }
+}

--- a/backend/server/src/test/java/shop/sellution/server/order/application/OrderServiceImplTest.java
+++ b/backend/server/src/test/java/shop/sellution/server/order/application/OrderServiceImplTest.java
@@ -381,18 +381,4 @@ class OrderServiceImplTest {
         verify(orderRepository).findById(orderId);
         verify(orderedProductRepository).findAllByOrderIdIn(List.of(orderId));
     }
-
-    @Test
-    @DisplayName("주문이 존재하지 않는 경우 예외를 던진다")
-    void checkStock_OrderNotFound_ThrowsException() {
-        // Given
-        Long orderId = 1L;
-        when(orderRepository.findById(orderId)).thenReturn(Optional.empty());
-
-        // When & Then
-        assertThatThrownBy(() -> orderService.checkStock(orderId))
-                .isInstanceOf(BadRequestException.class)
-                .hasMessageContaining("NOT_FOUND_ORDER");
-        verify(orderRepository).findById(orderId);
-    }
 }

--- a/backend/server/src/test/java/shop/sellution/server/order/presentation/OrderControllerTest.java
+++ b/backend/server/src/test/java/shop/sellution/server/order/presentation/OrderControllerTest.java
@@ -1,530 +1,572 @@
-//package shop.sellution.server.order.presentation;
-//
-//import com.fasterxml.jackson.databind.ObjectMapper;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-//import org.springframework.boot.test.mock.mockito.MockBean;
-//import org.springframework.data.domain.*;
-//import org.springframework.http.MediaType;
-//import org.springframework.restdocs.payload.JsonFieldType;
-//import org.springframework.test.util.ReflectionTestUtils;
-//import shop.sellution.server.address.dto.response.FindAddressSummaryRes;
-//import shop.sellution.server.common.BaseControllerTest;
-//import shop.sellution.server.company.domain.type.DayValueType;
-//import shop.sellution.server.customer.dto.resonse.FindCustomerSummaryRes;
-//import shop.sellution.server.global.type.DisplayStatus;
-//import shop.sellution.server.order.application.OrderCreationService;
-//import shop.sellution.server.order.application.OrderService;
-//import shop.sellution.server.order.domain.type.DeliveryStatus;
-//import shop.sellution.server.order.domain.type.OrderStatus;
-//import shop.sellution.server.order.domain.type.OrderType;
-//import shop.sellution.server.order.dto.OrderSearchCondition;
-//import shop.sellution.server.order.dto.request.CancelOrderReq;
-//import shop.sellution.server.order.dto.request.FindOrderedProductSimpleReq;
-//import shop.sellution.server.order.dto.request.SaveOrderReq;
-//import shop.sellution.server.order.dto.response.FindOrderRes;
-//import shop.sellution.server.order.dto.response.FindOrderedProductRes;
-//
-//import java.time.LocalDate;
-//import java.time.LocalDateTime;
-//import java.util.Arrays;
-//import java.util.Collections;
-//
-//import static org.mockito.ArgumentMatchers.*;
-//import static org.mockito.Mockito.doNothing;
-//import static org.mockito.Mockito.when;
-//
-//import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-//import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
-//import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
-//import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-//import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-//import static org.springframework.restdocs.request.RequestDocumentation.*;
-//
-//import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-//
-//
-//@WebMvcTest(OrderController.class)
-//class OrderControllerTest extends BaseControllerTest {
-//
-//    @MockBean
-//    private OrderService orderService;
-//
-//    @MockBean
-//    private OrderCreationService orderCreationService;
-//
-//    @Autowired
-//    private ObjectMapper objectMapper;
-//
-//    @DisplayName("고객 ID로 주문 목록을 조회한다")
-//    @Test
-//    void findAllOrderByCustomerId_Success() throws Exception {
-//        // Given
-//        Long customerId = 1L;
-//        FindOrderRes orderRes = FindOrderRes.builder()
-//                .customer(FindCustomerSummaryRes.builder()
-//                        .id(1L)
-//                        .name("길길")
-//                        .phoneNumber("010-1234-5678")
-//                        .build())
-//                .address(FindAddressSummaryRes.builder()
-//                        .id(1L)
-//                        .address("공릉")
-//                        .name("길길")
-//                        .zipcode("12345")
-//                        .addressDetail("아파트")
-//                        .phoneNumber("010-1234-5678")
-//                        .isDefaultAddress(DisplayStatus.Y)
-//                        .addressName("집")
-//                        .createdAt(LocalDateTime.now())
-//                        .build())
-//                .orderId(1L)
-//                .orderCode(123456L)
-//                .type(OrderType.ONETIME)
-//                .status(OrderStatus.APPROVED)
-//                .deliveryStatus(DeliveryStatus.IN_PROGRESS)
-//                .perPrice(20000)
-//                .totalPrice(100000)
-//                .deliveryStartDate(LocalDate.now())
-//                .nextDeliveryDate(LocalDate.now().plusDays(1))
-//                .deliveryEndDate(LocalDate.now().plusDays(7))
-//                .totalDeliveryCount(5)
-//                .remainingDeliveryCount(2)
-//                .orderedProductList(Collections.singletonList(
-//                        FindOrderedProductRes.builder()
-//                                .productId(1L)
-//                                .productName("Product A")
-//                                .count(2)
-//                                .discountRate(10)
-//                                .price(50000)
-//                                .build()
-//                ))
-//                .orderCreatedAt(LocalDateTime.now())
-//                .selectedDayList(Arrays.asList(DayValueType.MON, DayValueType.WED))
-//                .selectedWeekOption(1)
-//                .selectedMonthOption(1)
-//                .build();
-//
-//        Page<FindOrderRes> orderPage = new PageImpl<>(Collections.singletonList(orderRes));
-//        when(orderService.findAllOrderByCustomerId(eq(customerId), any())).thenReturn(orderPage);
-//
-//        // When & Then
-//        mockMvc.perform(get("/orders/customers/{customerId}", customerId)
-//                        .param("page", "0")
-//                        .param("size", "10"))
-//                .andExpect(status().isOk())
-//                .andDo(document("Order/order-list-by-customer",
-//                        preprocessRequest(prettyPrint()),
-//                        preprocessResponse(prettyPrint()),
-//                        pathParameters(
-//                                parameterWithName("customerId").description("고객 ID")
-//                        ),
-//                        queryParameters(
-//                                parameterWithName("page").description("페이지 번호"),
-//                                parameterWithName("size").description("페이지 크기")
-//                        ),
-//                        responseFields(
-//                                fieldWithPath("content[]").type(JsonFieldType.ARRAY).description("주문 목록"),
-//                                fieldWithPath("content[].orderId").type(JsonFieldType.NUMBER).description("주문 ID"),
-//                                fieldWithPath("content[].customer.id").type(JsonFieldType.NUMBER).description("고객 ID"),
-//                                fieldWithPath("content[].customer.name").type(JsonFieldType.STRING).description("고객 이름"),
-//                                fieldWithPath("content[].customer.phoneNumber").type(JsonFieldType.STRING).description("고객 전화번호"),
-//                                fieldWithPath("content[].address.id").type(JsonFieldType.NUMBER).description("주소 ID"),
-//                                fieldWithPath("content[].address.address").type(JsonFieldType.STRING).description("주소"),
-//                                fieldWithPath("content[].address.name").type(JsonFieldType.STRING).description("수령인 이름"),
-//                                fieldWithPath("content[].address.zipcode").type(JsonFieldType.STRING).description("우편번호"),
-//                                fieldWithPath("content[].address.addressDetail").type(JsonFieldType.STRING).description("상세주소"),
-//                                fieldWithPath("content[].address.phoneNumber").type(JsonFieldType.STRING).description("전화번호"),
-//                                fieldWithPath("content[].address.isDefaultAddress").type(JsonFieldType.STRING).description("기본 주소 여부"),
-//                                fieldWithPath("content[].address.addressName").type(JsonFieldType.STRING).description("주소 별칭"),
-//                                fieldWithPath("content[].address.createdAt").type(JsonFieldType.STRING).description("주소 생성일"),
-//                                fieldWithPath("content[].orderCode").type(JsonFieldType.NUMBER).description("주문 코드"),
-//                                fieldWithPath("content[].type").type(JsonFieldType.STRING).description("주문 유형"),
-//                                fieldWithPath("content[].status").type(JsonFieldType.STRING).description("주문 상태"),
-//                                fieldWithPath("content[].deliveryStatus").type(JsonFieldType.STRING).description("배송 상태"),
-//                                fieldWithPath("content[].perPrice").type(JsonFieldType.NUMBER).description("1회 배송 가격"),
-//                                fieldWithPath("content[].totalPrice").type(JsonFieldType.NUMBER).description("총 가격"),
-//                                fieldWithPath("content[].deliveryStartDate").type(JsonFieldType.STRING).description("배송 시작일"),
-//                                fieldWithPath("content[].nextDeliveryDate").type(JsonFieldType.STRING).description("다음 배송일"),
-//                                fieldWithPath("content[].deliveryEndDate").type(JsonFieldType.STRING).description("배송 종료일"),
-//                                fieldWithPath("content[].totalDeliveryCount").type(JsonFieldType.NUMBER).description("총 배송 횟수"),
-//                                fieldWithPath("content[].remainingDeliveryCount").type(JsonFieldType.NUMBER).description("남은 배송 횟수"),
-//                                fieldWithPath("content[].orderedProductList[]").type(JsonFieldType.ARRAY).description("주문된 상품 목록"),
-//                                fieldWithPath("content[].orderedProductList[].productId").type(JsonFieldType.NUMBER).description("주문된 상품 ID"),
-//                                fieldWithPath("content[].orderedProductList[].productName").type(JsonFieldType.STRING).description("주문된 상품 이름"),
-//                                fieldWithPath("content[].orderedProductList[].count").type(JsonFieldType.NUMBER).description("주문된 상품 수량"),
-//                                fieldWithPath("content[].orderedProductList[].discountRate").type(JsonFieldType.NUMBER).description("할인율"),
-//                                fieldWithPath("content[].orderedProductList[].price").type(JsonFieldType.NUMBER).description("주문된 상품 가격"),
-//                                fieldWithPath("content[].orderedProductList[].productImageList").type(JsonFieldType.ARRAY).optional().description("상품 이미지 목록"),
-//                                fieldWithPath("content[].orderCreatedAt").type(JsonFieldType.STRING).description("주문 생성일"),
-//                                fieldWithPath("content[].selectedDayList[]").type(JsonFieldType.ARRAY).description("선택된 요일 목록"),
-//                                fieldWithPath("content[].selectedWeekOption").type(JsonFieldType.NUMBER).description("선택된 주 옵션"),
-//                                fieldWithPath("content[].selectedMonthOption").type(JsonFieldType.NUMBER).description("선택된 월 옵션"),
-//                                fieldWithPath("content[].couponEventId").type(JsonFieldType.NUMBER).optional().description("쿠폰이벤트 ID"),
-//                                fieldWithPath("content[].couponName").type(JsonFieldType.STRING).optional().description("쿠폰 이름"),
-//                                fieldWithPath("content[].couponDiscountRate").type(JsonFieldType.NUMBER).optional().description("쿠폰 할인율"),
-//                                fieldWithPath("pageable").type(JsonFieldType.STRING).description("페이지 정보"),
-//                                fieldWithPath("totalElements").type(JsonFieldType.NUMBER).description("총 주문 수"),
-//                                fieldWithPath("totalPages").type(JsonFieldType.NUMBER).description("총 페이지 수"),
-//                                fieldWithPath("last").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부"),
-//                                fieldWithPath("size").type(JsonFieldType.NUMBER).description("페이지 크기"),
-//                                fieldWithPath("number").type(JsonFieldType.NUMBER).description("현재 페이지 번호"),
-//                                fieldWithPath("sort.empty").type(JsonFieldType.BOOLEAN).description("정렬이 비어 있는지 여부"),
-//                                fieldWithPath("sort.sorted").type(JsonFieldType.BOOLEAN).description("정렬되었는지 여부"),
-//                                fieldWithPath("sort.unsorted").type(JsonFieldType.BOOLEAN).description("정렬되지 않았는지 여부"),
-//                                fieldWithPath("numberOfElements").type(JsonFieldType.NUMBER).description("현재 페이지의 주문 수"),
-//                                fieldWithPath("first").type(JsonFieldType.BOOLEAN).description("첫 페이지 여부"),
-//                                fieldWithPath("empty").type(JsonFieldType.BOOLEAN).description("주문 목록이 비어있는지 여부")
-//                        )
-//                ));
-//
-//
-//    }
-//
-//    @DisplayName("회사 ID로 주문 목록을 조회한다")
-//    @Test
-//    void findAllOrderByCompanyId_Success() throws Exception {
-//        // Given
-//        Long companyId = 1L;
-//        FindOrderRes orderRes = FindOrderRes.builder()
-//                .customer(FindCustomerSummaryRes.builder().id(1L).name("길길").phoneNumber("010-1234-5678").build())
-//                .orderId(1L)
-//                .address(FindAddressSummaryRes.builder()
-//                        .id(1L)
-//                        .address("공릉")
-//                        .name("길길")
-//                        .zipcode("12345")
-//                        .addressDetail("아파트")
-//                        .phoneNumber("010-1234-5678")
-//                        .isDefaultAddress(DisplayStatus.Y)
-//                        .addressName("집")
-//                        .createdAt(LocalDateTime.now())
-//                        .build())
-//                .orderCode(123456L)
-//                .type(OrderType.ONETIME)
-//                .status(OrderStatus.APPROVED)
-//                .deliveryStatus(DeliveryStatus.IN_PROGRESS)
-//                .perPrice(10000)
-//                .totalPrice(100000)
-//                .deliveryStartDate(LocalDate.now())
-//                .nextDeliveryDate(LocalDate.now().plusDays(1))
-//                .deliveryEndDate(LocalDate.now().plusDays(7))
-//                .totalDeliveryCount(5)
-//                .remainingDeliveryCount(2)
-//                .orderedProductList(Collections.singletonList(FindOrderedProductRes.builder()
-//                        .productId(1L)
-//                        .productName("Product A")
-//                        .count(2)
-//                        .price(50000)
-//                        .discountRate(10)
-//                        .build()))
-//                .orderCreatedAt(LocalDateTime.now())
-//                .selectedDayList(Arrays.asList(DayValueType.MON, DayValueType.WED))
-//                .selectedWeekOption(1)
-//                .selectedMonthOption(1)
-//                .build();
-//        Page<FindOrderRes> orderPage = new PageImpl<>(Collections.singletonList(orderRes));
-//        when(orderService.findAllOrderByCompanyId(eq(companyId), any(OrderSearchCondition.class), any(Pageable.class)))
-//                .thenReturn(orderPage);
-//
-//        // When & Then
-//        mockMvc.perform(get("/orders/company/{companyId}", companyId)
-//                        .param("page", "0")
-//                        .param("size", "10"))
-//                .andExpect(status().isOk())
-//                .andDo(document("Order/order-list-by-company",
-//                        preprocessRequest(prettyPrint()),
-//                        preprocessResponse(prettyPrint()),
-//                        pathParameters(
-//                                parameterWithName("companyId").description("회사 ID")
-//                        ),
-//                        queryParameters(
-//                                parameterWithName("page").description("페이지 번호"),
-//                                parameterWithName("size").description("페이지 크기")
-//                        ),
-//                        responseFields(
-//                                fieldWithPath("content").type(JsonFieldType.ARRAY).description("주문 목록"),
-//                                fieldWithPath("content[].orderId").type(JsonFieldType.NUMBER).description("주문 ID"),
-//                                fieldWithPath("content[].customer").type(JsonFieldType.OBJECT).optional().description("고객 정보"),
-//                                fieldWithPath("content[].customer.id").type(JsonFieldType.NUMBER).optional().description("고객 ID"),
-//                                fieldWithPath("content[].customer.name").type(JsonFieldType.STRING).optional().description("고객 이름"),
-//                                fieldWithPath("content[].customer.phoneNumber").type(JsonFieldType.STRING).optional().description("고객 전화번호"),
-//                                fieldWithPath("content[].address").type(JsonFieldType.OBJECT).optional().description("주소 정보"),
-//                                fieldWithPath("content[].address.id").type(JsonFieldType.NUMBER).optional().description("주소 ID"),
-//                                fieldWithPath("content[].address.address").type(JsonFieldType.STRING).optional().description("주소"),
-//                                fieldWithPath("content[].address.name").type(JsonFieldType.STRING).optional().description("수령인 이름"),
-//                                fieldWithPath("content[].address.zipcode").type(JsonFieldType.STRING).optional().description("우편번호"),
-//                                fieldWithPath("content[].address.addressDetail").type(JsonFieldType.STRING).optional().description("상세 주소"),
-//                                fieldWithPath("content[].address.phoneNumber").type(JsonFieldType.STRING).optional().description("전화번호"),
-//                                fieldWithPath("content[].address.isDefaultAddress").type(JsonFieldType.STRING).optional().description("기본 주소 여부"),
-//                                fieldWithPath("content[].address.addressName").type(JsonFieldType.STRING).optional().description("주소 별칭"),
-//                                fieldWithPath("content[].address.createdAt").type(JsonFieldType.STRING).optional().description("주소 생성일"),
-//                                fieldWithPath("content[].orderCode").type(JsonFieldType.NUMBER).description("주문 코드"),
-//                                fieldWithPath("content[].type").type(JsonFieldType.STRING).description("주문 유형"),
-//                                fieldWithPath("content[].status").type(JsonFieldType.STRING).description("주문 상태"),
-//                                fieldWithPath("content[].deliveryStatus").type(JsonFieldType.STRING).description("배송 상태"),
-//                                fieldWithPath("content[].perPrice").type(JsonFieldType.NUMBER).description("1회 배송 가격"),
-//                                fieldWithPath("content[].totalPrice").type(JsonFieldType.NUMBER).description("총 가격"),
-//                                fieldWithPath("content[].deliveryStartDate").type(JsonFieldType.STRING).description("배송 시작일"),
-//                                fieldWithPath("content[].nextDeliveryDate").type(JsonFieldType.STRING).optional().description("다음 배송일"),
-//                                fieldWithPath("content[].deliveryEndDate").type(JsonFieldType.STRING).description("배송 종료일"),
-//                                fieldWithPath("content[].totalDeliveryCount").type(JsonFieldType.NUMBER).description("총 배송 횟수"),
-//                                fieldWithPath("content[].remainingDeliveryCount").type(JsonFieldType.NUMBER).description("남은 배송 횟수"),
-//                                fieldWithPath("content[].orderedProductList").type(JsonFieldType.ARRAY).description("주문된 상품 목록"),
-//                                fieldWithPath("content[].orderedProductList[].productId").type(JsonFieldType.NUMBER).description("상품 ID"),
-//                                fieldWithPath("content[].orderedProductList[].productName").type(JsonFieldType.STRING).description("상품 이름"),
-//                                fieldWithPath("content[].orderedProductList[].count").type(JsonFieldType.NUMBER).description("상품 수량"),
-//                                fieldWithPath("content[].orderedProductList[].price").type(JsonFieldType.NUMBER).description("상품 가격"),
-//                                fieldWithPath("content[].orderedProductList[].discountRate").type(JsonFieldType.NUMBER).description("할인율"),
-//                                fieldWithPath("content[].orderedProductList[].productImageList").type(JsonFieldType.ARRAY).optional().description("상품 이미지 목록"),
-//                                fieldWithPath("content[].orderCreatedAt").type(JsonFieldType.STRING).description("주문 생성일"),
-//                                fieldWithPath("content[].selectedDayList").type(JsonFieldType.ARRAY).description("선택된 요일 목록"),
-//                                fieldWithPath("content[].selectedWeekOption").type(JsonFieldType.NUMBER).optional().description("선택된 주 옵션"),
-//                                fieldWithPath("content[].selectedMonthOption").type(JsonFieldType.NUMBER).optional().description("선택된 월 옵션"),
-//                                fieldWithPath("content[].couponEventId").type(JsonFieldType.NUMBER).optional().description("쿠폰이벤트 ID"),
-//                                fieldWithPath("content[].couponName").type(JsonFieldType.STRING).optional().description("쿠폰 이름"),
-//                                fieldWithPath("content[].couponDiscountRate").type(JsonFieldType.NUMBER).optional().description("쿠폰 할인율"),
-//                                fieldWithPath("pageable").type(JsonFieldType.STRING).description("페이지 정보"),
-//                                fieldWithPath("totalElements").type(JsonFieldType.NUMBER).description("총 주문 수"),
-//                                fieldWithPath("totalPages").type(JsonFieldType.NUMBER).description("총 페이지 수"),
-//                                fieldWithPath("last").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부"),
-//                                fieldWithPath("size").type(JsonFieldType.NUMBER).description("페이지 크기"),
-//                                fieldWithPath("number").type(JsonFieldType.NUMBER).description("현재 페이지 번호"),
-//                                fieldWithPath("sort").type(JsonFieldType.OBJECT).description("정렬 정보"),
-//                                fieldWithPath("sort.empty").type(JsonFieldType.BOOLEAN).description("정렬이 비어 있는지 여부"),
-//                                fieldWithPath("sort.sorted").type(JsonFieldType.BOOLEAN).description("정렬되었는지 여부"),
-//                                fieldWithPath("sort.unsorted").type(JsonFieldType.BOOLEAN).description("정렬되지 않았는지 여부"),
-//                                fieldWithPath("numberOfElements").type(JsonFieldType.NUMBER).description("현재 페이지의 주문 수"),
-//                                fieldWithPath("first").type(JsonFieldType.BOOLEAN).description("첫 페이지 여부"),
-//                                fieldWithPath("empty").type(JsonFieldType.BOOLEAN).description("주문 목록이 비어있는지 여부")
-//                        )
-//                ));
-//    }
-//
-//    @DisplayName("주문을 생성한다")
-//    @Test
-//    void order_Success() throws Exception {
-//        // Given
-//        Long customerId = 1L;
-//        SaveOrderReq saveOrderReq = SaveOrderReq.builder()
-//                .companyId(1L)
-//                .addressId(1L)
-//                .accountId(1L)
-//                .eventId(1L)
-//                .orderType(OrderType.ONETIME)
-//                .deliveryStartDate(LocalDate.now().plusDays(3))
-//                .orderedProducts(Collections.singletonList(
-//                        FindOrderedProductSimpleReq.builder()
-//                                .productId(1L)
-//                                .count(2)
-//                                .discountRate(10)
-//                                .price(1000)
-//                                .build()
-//                ))
-//                .build();
-//
-//        when(orderCreationService.createOrder(eq(customerId), any(SaveOrderReq.class))).thenReturn(1L);
-//
-//        // When & Then
-//        mockMvc.perform(post("/orders/customers/{customerId}", customerId)
-//                        .contentType(MediaType.APPLICATION_JSON)
-//                        .content(objectMapper.writeValueAsString(saveOrderReq)))
-//                .andExpect(status().isOk())
-//                .andExpect(content().string("success, 생성된 아이디 : 1"))
-//                .andDo(document("Order/create-order",
-//                        preprocessRequest(prettyPrint()),
-//                        preprocessResponse(prettyPrint()),
-//                        pathParameters(
-//                                parameterWithName("customerId").description("고객 ID")
-//                        ),
-//                        requestFields(
-//                                fieldWithPath("companyId").type(JsonFieldType.NUMBER).description("회사 ID"),
-//                                fieldWithPath("addressId").type(JsonFieldType.NUMBER).description("주소 ID"),
-//                                fieldWithPath("accountId").type(JsonFieldType.NUMBER).description("계정 ID"),
-//                                fieldWithPath("eventId").type(JsonFieldType.NUMBER).description("쿠폰이벤트 ID"),
-//                                fieldWithPath("monthOptionId").type(JsonFieldType.NUMBER).optional().description("월 옵션 ID"),
-//                                fieldWithPath("weekOptionId").type(JsonFieldType.NUMBER).optional().description("주 옵션 ID"),
-//                                fieldWithPath("orderType").type(JsonFieldType.STRING).description("주문 타입"),
-//                                fieldWithPath("totalDeliveryCount").type(JsonFieldType.NUMBER).optional().description("총 배송 횟수"),
-//                                fieldWithPath("deliveryStartDate").type(JsonFieldType.STRING).description("배송 시작일"),
-//                                fieldWithPath("orderedProducts").type(JsonFieldType.ARRAY).description("주문 상품 목록"),
-//                                fieldWithPath("orderedProducts[].productId").type(JsonFieldType.NUMBER).description("상품 ID"),
-//                                fieldWithPath("orderedProducts[].count").type(JsonFieldType.NUMBER).description("상품 수량"),
-//                                fieldWithPath("orderedProducts[].discountRate").type(JsonFieldType.NUMBER).optional().description("할인율"),
-//                                fieldWithPath("orderedProducts[].price").type(JsonFieldType.NUMBER).optional().description("가격"),
-//                                fieldWithPath("dayOptionIds").type(JsonFieldType.ARRAY).optional().description("요일 옵션 ID 목록")
-//                        )
-//                ));
-//    }
-//
-//    @DisplayName("주문을 취소한다")
-//    @Test
-//    void cancelOrder_Success() throws Exception {
-//        // Given
-//        Long orderId = 1L;
-//        CancelOrderReq cancelOrderReq = new CancelOrderReq();
-//        ReflectionTestUtils.setField(cancelOrderReq, "customerId", 1L);
-//        ReflectionTestUtils.setField(cancelOrderReq, "accountId", 1L);
-//
-//        doNothing().when(orderService).cancelOrder(eq(orderId), any(CancelOrderReq.class));
-//
-//        // When & Then
-//        mockMvc.perform(post("/orders/{orderId}/cancel", orderId)
-//                        .contentType(MediaType.APPLICATION_JSON)
-//                        .content(objectMapper.writeValueAsString(cancelOrderReq)))
-//                .andExpect(status().isOk())
-//                .andExpect(content().string("success"))
-//                .andDo(document("Order/cancel-order",
-//                        preprocessRequest(prettyPrint()),
-//                        preprocessResponse(prettyPrint()),
-//                        pathParameters(
-//                                parameterWithName("orderId").description("주문 ID")
-//                        ),
-//                        requestFields(
-//                                fieldWithPath("customerId").type(JsonFieldType.NUMBER).description("고객 ID"),
-//                                fieldWithPath("accountId").type(JsonFieldType.NUMBER).description("계정 ID")
-//                        )
-//                ));
-//    }
-//
-//    @DisplayName("주문을 승인한다")
-//    @Test
-//    void approveOrder_Success() throws Exception {
-//        // Given
-//        Long orderId = 1L;
-//
-//        doNothing().when(orderService).approveOrder(orderId);
-//
-//        // When & Then
-//        mockMvc.perform(post("/orders/{orderId}/approve", orderId))
-//                .andExpect(status().isOk())
-//                .andExpect(content().string("success"))
-//                .andDo(document("Order/approve-order",
-//                        preprocessRequest(prettyPrint()),
-//                        preprocessResponse(prettyPrint()),
-//                        pathParameters(
-//                                parameterWithName("orderId").description("주문 ID")
-//                        )
-//                ));
-//    }
-//    @DisplayName("주문 자동 승인을 토글한다")
-//    @Test
-//    void toggleAutoApprove_Success() throws Exception {
-//        // Given
-//        Long companyId = 1L;
-//
-//        doNothing().when(orderService).toggleAutoApprove(companyId);
-//
-//        // When & Then
-//        mockMvc.perform(post("/orders/auto-approve-toggle/company/{companyId}", companyId)
-//                        .contentType(MediaType.APPLICATION_JSON))
-//                .andExpect(status().isOk())
-//                .andExpect(content().string("success"))
-//                .andDo(document("Order/toggle-auto-approve",
-//                        preprocessRequest(prettyPrint()),
-//                        preprocessResponse(prettyPrint()),
-//                        pathParameters(
-//                                parameterWithName("companyId").description("회사 ID")
-//                        )
-//                ));
-//    }
-//
-//    @DisplayName("주문 ID로 주문을 조회한다")
-//    @Test
-//    void findOrderById_Success() throws Exception {
-//        // Given
-//        Long orderId = 1L;
-//        FindOrderRes orderRes = FindOrderRes.builder()
-//                .customer(FindCustomerSummaryRes.builder().id(1L).name("Test Customer").phoneNumber("010-1234-5678").build())
-//                .orderId(1L)
-//                .address(FindAddressSummaryRes.builder()
-//                        .id(1L)
-//                        .address("Test Address")
-//                        .name("Test Name")
-//                        .zipcode("12345")
-//                        .addressDetail("Test Detail")
-//                        .phoneNumber("010-1234-5678")
-//                        .isDefaultAddress(DisplayStatus.Y)
-//                        .addressName("Home")
-//                        .createdAt(LocalDateTime.now())
-//                        .build())
-//                .orderCode(123456L)
-//                .type(OrderType.ONETIME)
-//                .status(OrderStatus.APPROVED)
-//                .deliveryStatus(DeliveryStatus.IN_PROGRESS)
-//                .perPrice(20000)
-//                .totalPrice(100000)
-//                .deliveryStartDate(LocalDate.now())
-//                .nextDeliveryDate(LocalDate.now().plusDays(1))
-//                .deliveryEndDate(LocalDate.now().plusDays(7))
-//                .totalDeliveryCount(1)
-//                .remainingDeliveryCount(1)
-//                .orderedProductList(Collections.singletonList(FindOrderedProductRes.builder()
-//                        .productId(1L)
-//                        .productName("Test Product")
-//                        .count(2)
-//                        .price(50000)
-//                        .discountRate(10)
-//                        .build()))
-//                .orderCreatedAt(LocalDateTime.now())
-//                .nextDeliveryDate(LocalDate.now().plusDays(1))
-//                .build();
-//
-//        when(orderService.findOrder(orderId)).thenReturn(orderRes);
-//
-//        // When & Then
-//        mockMvc.perform(get("/orders/{orderId}", orderId))
-//                .andExpect(status().isOk())
-//                .andDo(document("Order/find-order-by-id",
-//                        preprocessRequest(prettyPrint()),
-//                        preprocessResponse(prettyPrint()),
-//                        pathParameters(
-//                                parameterWithName("orderId").description("주문 ID")
-//                        ),
-//                        responseFields(
-//                                fieldWithPath("orderId").type(JsonFieldType.NUMBER).description("주문 ID"),
-//                                fieldWithPath("customer").type(JsonFieldType.OBJECT).description("고객 정보"),
-//                                fieldWithPath("customer.id").type(JsonFieldType.NUMBER).description("고객 ID"),
-//                                fieldWithPath("customer.name").type(JsonFieldType.STRING).description("고객 이름"),
-//                                fieldWithPath("customer.phoneNumber").type(JsonFieldType.STRING).description("고객 전화번호"),
-//                                fieldWithPath("address").type(JsonFieldType.OBJECT).description("주소 정보"),
-//                                fieldWithPath("address.id").type(JsonFieldType.NUMBER).description("주소 ID"),
-//                                fieldWithPath("address.address").type(JsonFieldType.STRING).description("주소"),
-//                                fieldWithPath("address.name").type(JsonFieldType.STRING).description("수령인 이름"),
-//                                fieldWithPath("address.zipcode").type(JsonFieldType.STRING).description("우편번호"),
-//                                fieldWithPath("address.addressDetail").type(JsonFieldType.STRING).description("상세 주소"),
-//                                fieldWithPath("address.phoneNumber").type(JsonFieldType.STRING).description("전화번호"),
-//                                fieldWithPath("address.isDefaultAddress").type(JsonFieldType.STRING).description("기본 주소 여부"),
-//                                fieldWithPath("address.addressName").type(JsonFieldType.STRING).description("주소 별칭"),
-//                                fieldWithPath("address.createdAt").type(JsonFieldType.STRING).description("주소 생성일"),
-//                                fieldWithPath("orderCode").type(JsonFieldType.NUMBER).description("주문 코드"),
-//                                fieldWithPath("type").type(JsonFieldType.STRING).description("주문 유형"),
-//                                fieldWithPath("status").type(JsonFieldType.STRING).description("주문 상태"),
-//                                fieldWithPath("deliveryStatus").type(JsonFieldType.STRING).description("배송 상태"),
-//                                fieldWithPath("perPrice").type(JsonFieldType.NUMBER).description("1회 배송 가격"),
-//                                fieldWithPath("totalPrice").type(JsonFieldType.NUMBER).description("총 가격"),
-//                                fieldWithPath("deliveryStartDate").type(JsonFieldType.STRING).description("배송 시작일"),
-//                                fieldWithPath("deliveryEndDate").type(JsonFieldType.STRING).description("배송 종료일"),
-//                                fieldWithPath("nextDeliveryDate").type(JsonFieldType.STRING).description("다음 배송일"),
-//                                fieldWithPath("totalDeliveryCount").type(JsonFieldType.NUMBER).description("총 배송 횟수"),
-//                                fieldWithPath("remainingDeliveryCount").type(JsonFieldType.NUMBER).description("남은 배송 횟수"),
-//                                fieldWithPath("orderedProductList").type(JsonFieldType.ARRAY).description("주문된 상품 목록"),
-//                                fieldWithPath("orderedProductList[].productId").type(JsonFieldType.NUMBER).description("상품 ID"),
-//                                fieldWithPath("orderedProductList[].productName").type(JsonFieldType.STRING).description("상품 이름"),
-//                                fieldWithPath("orderedProductList[].count").type(JsonFieldType.NUMBER).description("상품 수량"),
-//                                fieldWithPath("orderedProductList[].price").type(JsonFieldType.NUMBER).description("상품 가격"),
-//                                fieldWithPath("orderedProductList[].discountRate").type(JsonFieldType.NUMBER).description("할인율"),
-//                                fieldWithPath("orderedProductList[].productImageList").type(JsonFieldType.ARRAY).optional().description("상품 이미지 목록"),
-//                                fieldWithPath("orderCreatedAt").type(JsonFieldType.STRING).description("주문 생성일"),
-//                                fieldWithPath("selectedDayList").type(JsonFieldType.ARRAY).optional().description("선택된 배송 요일 목록"),
-//                                fieldWithPath("selectedWeekOption").type(JsonFieldType.STRING).optional().description("선택된 주 옵션"),
-//                                fieldWithPath("selectedMonthOption").type(JsonFieldType.STRING).optional().description("선택된 월 옵션"),
-//                                fieldWithPath("couponEventId").type(JsonFieldType.NUMBER).optional().description("쿠폰이벤트 ID"),
-//                                fieldWithPath("couponName").type(JsonFieldType.STRING).optional().description("쿠폰 이름"),
-//                                fieldWithPath("couponDiscountRate").type(JsonFieldType.NUMBER).optional().description("쿠폰 할인율")
-//                        )
-//                ));
-//    }
-//}
+package shop.sellution.server.order.presentation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.*;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.util.ReflectionTestUtils;
+import shop.sellution.server.address.dto.response.FindAddressSummaryRes;
+import shop.sellution.server.common.BaseControllerTest;
+import shop.sellution.server.company.domain.type.DayValueType;
+import shop.sellution.server.customer.dto.resonse.FindCustomerSummaryRes;
+import shop.sellution.server.global.type.DisplayStatus;
+import shop.sellution.server.order.application.OrderCreationService;
+import shop.sellution.server.order.application.OrderService;
+import shop.sellution.server.order.domain.type.DeliveryStatus;
+import shop.sellution.server.order.domain.type.OrderStatus;
+import shop.sellution.server.order.domain.type.OrderType;
+import shop.sellution.server.order.dto.OrderSearchCondition;
+import shop.sellution.server.order.dto.request.CancelOrderReq;
+import shop.sellution.server.order.dto.request.FindOrderedProductSimpleReq;
+import shop.sellution.server.order.dto.request.SaveOrderReq;
+import shop.sellution.server.order.dto.response.FindOrderRes;
+import shop.sellution.server.order.dto.response.FindOrderedProductRes;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+@WebMvcTest(OrderController.class)
+class OrderControllerTest extends BaseControllerTest {
+
+    @MockBean
+    private OrderService orderService;
+
+    @MockBean
+    private OrderCreationService orderCreationService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @DisplayName("고객 ID로 주문 목록을 조회한다")
+    @Test
+    void findAllOrderByCustomerId_Success() throws Exception {
+        // Given
+        Long customerId = 1L;
+        FindOrderRes orderRes = FindOrderRes.builder()
+                .customer(FindCustomerSummaryRes.builder()
+                        .id(1L)
+                        .name("길길")
+                        .phoneNumber("010-1234-5678")
+                        .build())
+                .address(FindAddressSummaryRes.builder()
+                        .id(1L)
+                        .address("공릉")
+                        .name("길길")
+                        .zipcode("12345")
+                        .addressDetail("아파트")
+                        .phoneNumber("010-1234-5678")
+                        .isDefaultAddress(DisplayStatus.Y)
+                        .addressName("집")
+                        .createdAt(LocalDateTime.now())
+                        .build())
+                .orderId(1L)
+                .orderCode("123456")
+                .type(OrderType.ONETIME)
+                .status(OrderStatus.APPROVED)
+                .deliveryStatus(DeliveryStatus.IN_PROGRESS)
+                .perPrice(20000)
+                .totalPrice(100000)
+                .deliveryStartDate(LocalDate.now())
+                .nextDeliveryDate(LocalDate.now().plusDays(1))
+                .deliveryEndDate(LocalDate.now().plusDays(7))
+                .totalDeliveryCount(5)
+                .remainingDeliveryCount(2)
+                .orderedProductList(Collections.singletonList(
+                        FindOrderedProductRes.builder()
+                                .productId(1L)
+                                .productName("Product A")
+                                .count(2)
+                                .discountRate(10)
+                                .price(50000)
+                                .build()
+                ))
+                .orderCreatedAt(LocalDateTime.now())
+                .selectedDayList(Arrays.asList(DayValueType.MON, DayValueType.WED))
+                .selectedWeekOption(1)
+                .selectedMonthOption(1)
+                .build();
+
+        Page<FindOrderRes> orderPage = new PageImpl<>(Collections.singletonList(orderRes));
+        when(orderService.findAllOrderByCustomerId(eq(customerId), any())).thenReturn(orderPage);
+
+        // When & Then
+        mockMvc.perform(get("/orders/customers/{customerId}", customerId)
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andDo(document("Order/order-list-by-customer",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("customerId").description("고객 ID")
+                        ),
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호"),
+                                parameterWithName("size").description("페이지 크기")
+                        ),
+                        responseFields(
+                                fieldWithPath("content[]").type(JsonFieldType.ARRAY).description("주문 목록"),
+                                fieldWithPath("content[].orderId").type(JsonFieldType.NUMBER).description("주문 ID"),
+                                fieldWithPath("content[].customer.id").type(JsonFieldType.NUMBER).description("고객 ID"),
+                                fieldWithPath("content[].customer.name").type(JsonFieldType.STRING).description("고객 이름"),
+                                fieldWithPath("content[].customer.phoneNumber").type(JsonFieldType.STRING).description("고객 전화번호"),
+                                fieldWithPath("content[].address.id").type(JsonFieldType.NUMBER).description("주소 ID"),
+                                fieldWithPath("content[].address.address").type(JsonFieldType.STRING).description("주소"),
+                                fieldWithPath("content[].address.name").type(JsonFieldType.STRING).description("수령인 이름"),
+                                fieldWithPath("content[].accountId").type(JsonFieldType.NUMBER).optional().description("계정 ID"),
+                                fieldWithPath("content[].paymentCount").type(JsonFieldType.NUMBER).optional().description("결제 횟수"),
+                                fieldWithPath("content[].nextPaymentDate").type(JsonFieldType.STRING).optional().description("다음 결제일"),
+                                fieldWithPath("content[].thisMonthDeliveryCount").type(JsonFieldType.NUMBER).optional().description("이번 달 배송 횟수"),
+                                fieldWithPath("content[].address.zipcode").type(JsonFieldType.STRING).description("우편번호"),
+                                fieldWithPath("content[].address.addressDetail").type(JsonFieldType.STRING).description("상세주소"),
+                                fieldWithPath("content[].address.phoneNumber").type(JsonFieldType.STRING).description("전화번호"),
+                                fieldWithPath("content[].address.isDefaultAddress").type(JsonFieldType.STRING).description("기본 주소 여부"),
+                                fieldWithPath("content[].address.addressName").type(JsonFieldType.STRING).description("주소 별칭"),
+                                fieldWithPath("content[].address.createdAt").type(JsonFieldType.STRING).description("주소 생성일"),
+                                fieldWithPath("content[].orderCode").type(JsonFieldType.STRING).description("주문 코드"),
+                                fieldWithPath("content[].type").type(JsonFieldType.STRING).description("주문 유형"),
+                                fieldWithPath("content[].status").type(JsonFieldType.STRING).description("주문 상태"),
+                                fieldWithPath("content[].deliveryStatus").type(JsonFieldType.STRING).description("배송 상태"),
+                                fieldWithPath("content[].perPrice").type(JsonFieldType.NUMBER).description("1회 배송 가격"),
+                                fieldWithPath("content[].totalPrice").type(JsonFieldType.NUMBER).description("총 가격"),
+                                fieldWithPath("content[].deliveryStartDate").type(JsonFieldType.STRING).description("배송 시작일"),
+                                fieldWithPath("content[].nextDeliveryDate").type(JsonFieldType.STRING).description("다음 배송일"),
+                                fieldWithPath("content[].deliveryEndDate").type(JsonFieldType.STRING).description("배송 종료일"),
+                                fieldWithPath("content[].totalDeliveryCount").type(JsonFieldType.NUMBER).description("총 배송 횟수"),
+                                fieldWithPath("content[].remainingDeliveryCount").type(JsonFieldType.NUMBER).description("남은 배송 횟수"),
+                                fieldWithPath("content[].orderedProductList[]").type(JsonFieldType.ARRAY).description("주문된 상품 목록"),
+                                fieldWithPath("content[].orderedProductList[].productId").type(JsonFieldType.NUMBER).description("주문된 상품 ID"),
+                                fieldWithPath("content[].orderedProductList[].productName").type(JsonFieldType.STRING).description("주문된 상품 이름"),
+                                fieldWithPath("content[].orderedProductList[].count").type(JsonFieldType.NUMBER).description("주문된 상품 수량"),
+                                fieldWithPath("content[].orderedProductList[].discountRate").type(JsonFieldType.NUMBER).description("할인율"),
+                                fieldWithPath("content[].orderedProductList[].price").type(JsonFieldType.NUMBER).description("주문된 상품 가격"),
+                                fieldWithPath("content[].orderedProductList[].productImageList").type(JsonFieldType.ARRAY).optional().description("상품 이미지 목록"),
+                                fieldWithPath("content[].orderCreatedAt").type(JsonFieldType.STRING).description("주문 생성일"),
+                                fieldWithPath("content[].selectedDayList[]").type(JsonFieldType.ARRAY).description("선택된 요일 목록"),
+                                fieldWithPath("content[].selectedWeekOption").type(JsonFieldType.NUMBER).description("선택된 주 옵션"),
+                                fieldWithPath("content[].selectedMonthOption").type(JsonFieldType.NUMBER).description("선택된 월 옵션"),
+                                fieldWithPath("content[].couponEventId").type(JsonFieldType.NUMBER).optional().description("쿠폰이벤트 ID"),
+                                fieldWithPath("content[].couponName").type(JsonFieldType.STRING).optional().description("쿠폰 이름"),
+                                fieldWithPath("content[].couponDiscountRate").type(JsonFieldType.NUMBER).optional().description("쿠폰 할인율"),
+                                fieldWithPath("pageable").type(JsonFieldType.STRING).description("페이지 정보"),
+                                fieldWithPath("totalElements").type(JsonFieldType.NUMBER).description("총 주문 수"),
+                                fieldWithPath("totalPages").type(JsonFieldType.NUMBER).description("총 페이지 수"),
+                                fieldWithPath("last").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부"),
+                                fieldWithPath("size").type(JsonFieldType.NUMBER).description("페이지 크기"),
+                                fieldWithPath("number").type(JsonFieldType.NUMBER).description("현재 페이지 번호"),
+                                fieldWithPath("sort.empty").type(JsonFieldType.BOOLEAN).description("정렬이 비어 있는지 여부"),
+                                fieldWithPath("sort.sorted").type(JsonFieldType.BOOLEAN).description("정렬되었는지 여부"),
+                                fieldWithPath("sort.unsorted").type(JsonFieldType.BOOLEAN).description("정렬되지 않았는지 여부"),
+                                fieldWithPath("numberOfElements").type(JsonFieldType.NUMBER).description("현재 페이지의 주문 수"),
+                                fieldWithPath("first").type(JsonFieldType.BOOLEAN).description("첫 페이지 여부"),
+                                fieldWithPath("empty").type(JsonFieldType.BOOLEAN).description("주문 목록이 비어있는지 여부")
+                        )
+                ));
+
+
+    }
+
+    @DisplayName("회사 ID로 주문 목록을 조회한다")
+    @Test
+    void findAllOrderByCompanyId_Success() throws Exception {
+        // Given
+        Long companyId = 1L;
+        FindOrderRes orderRes = FindOrderRes.builder()
+                .customer(FindCustomerSummaryRes.builder().id(1L).name("길길").phoneNumber("010-1234-5678").build())
+                .orderId(1L)
+                .address(FindAddressSummaryRes.builder()
+                        .id(1L)
+                        .address("공릉")
+                        .name("길길")
+                        .zipcode("12345")
+                        .addressDetail("아파트")
+                        .phoneNumber("010-1234-5678")
+                        .isDefaultAddress(DisplayStatus.Y)
+                        .addressName("집")
+                        .createdAt(LocalDateTime.now())
+                        .build())
+                .orderCode("123456")
+                .type(OrderType.ONETIME)
+                .status(OrderStatus.APPROVED)
+                .deliveryStatus(DeliveryStatus.IN_PROGRESS)
+                .perPrice(10000)
+                .totalPrice(100000)
+                .deliveryStartDate(LocalDate.now())
+                .nextDeliveryDate(LocalDate.now().plusDays(1))
+                .deliveryEndDate(LocalDate.now().plusDays(7))
+                .totalDeliveryCount(5)
+                .remainingDeliveryCount(2)
+                .orderedProductList(Collections.singletonList(FindOrderedProductRes.builder()
+                        .productId(1L)
+                        .productName("Product A")
+                        .count(2)
+                        .price(50000)
+                        .discountRate(10)
+                        .build()))
+                .orderCreatedAt(LocalDateTime.now())
+                .selectedDayList(Arrays.asList(DayValueType.MON, DayValueType.WED))
+                .selectedWeekOption(1)
+                .selectedMonthOption(1)
+                .build();
+        Page<FindOrderRes> orderPage = new PageImpl<>(Collections.singletonList(orderRes));
+        when(orderService.findAllOrderByCompanyId(eq(companyId), any(OrderSearchCondition.class), any(Pageable.class)))
+                .thenReturn(orderPage);
+
+        // When & Then
+        mockMvc.perform(get("/orders/company/{companyId}", companyId)
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andDo(document("Order/order-list-by-company",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("companyId").description("회사 ID")
+                        ),
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호"),
+                                parameterWithName("size").description("페이지 크기")
+                        ),
+                        responseFields(
+                                fieldWithPath("content").type(JsonFieldType.ARRAY).description("주문 목록"),
+                                fieldWithPath("content[].orderId").type(JsonFieldType.NUMBER).description("주문 ID"),
+                                fieldWithPath("content[].customer").type(JsonFieldType.OBJECT).optional().description("고객 정보"),
+                                fieldWithPath("content[].customer.id").type(JsonFieldType.NUMBER).optional().description("고객 ID"),
+                                fieldWithPath("content[].accountId").type(JsonFieldType.NUMBER).optional().description("계정 ID"),
+                                fieldWithPath("content[].paymentCount").type(JsonFieldType.NUMBER).optional().description("결제 횟수"),
+                                fieldWithPath("content[].nextPaymentDate").type(JsonFieldType.STRING).optional().description("다음 결제일"),
+                                fieldWithPath("content[].thisMonthDeliveryCount").type(JsonFieldType.NUMBER).optional().description("이번 달 배송 횟수"),
+                                fieldWithPath("content[].customer.name").type(JsonFieldType.STRING).optional().description("고객 이름"),
+                                fieldWithPath("content[].customer.phoneNumber").type(JsonFieldType.STRING).optional().description("고객 전화번호"),
+                                fieldWithPath("content[].address").type(JsonFieldType.OBJECT).optional().description("주소 정보"),
+                                fieldWithPath("content[].address.id").type(JsonFieldType.NUMBER).optional().description("주소 ID"),
+                                fieldWithPath("content[].address.address").type(JsonFieldType.STRING).optional().description("주소"),
+                                fieldWithPath("content[].address.name").type(JsonFieldType.STRING).optional().description("수령인 이름"),
+                                fieldWithPath("content[].address.zipcode").type(JsonFieldType.STRING).optional().description("우편번호"),
+                                fieldWithPath("content[].address.addressDetail").type(JsonFieldType.STRING).optional().description("상세 주소"),
+                                fieldWithPath("content[].address.phoneNumber").type(JsonFieldType.STRING).optional().description("전화번호"),
+                                fieldWithPath("content[].address.isDefaultAddress").type(JsonFieldType.STRING).optional().description("기본 주소 여부"),
+                                fieldWithPath("content[].address.addressName").type(JsonFieldType.STRING).optional().description("주소 별칭"),
+                                fieldWithPath("content[].address.createdAt").type(JsonFieldType.STRING).optional().description("주소 생성일"),
+                                fieldWithPath("content[].orderCode").type(JsonFieldType.STRING).description("주문 코드"),
+                                fieldWithPath("content[].type").type(JsonFieldType.STRING).description("주문 유형"),
+                                fieldWithPath("content[].status").type(JsonFieldType.STRING).description("주문 상태"),
+                                fieldWithPath("content[].deliveryStatus").type(JsonFieldType.STRING).description("배송 상태"),
+                                fieldWithPath("content[].perPrice").type(JsonFieldType.NUMBER).description("1회 배송 가격"),
+                                fieldWithPath("content[].totalPrice").type(JsonFieldType.NUMBER).description("총 가격"),
+                                fieldWithPath("content[].deliveryStartDate").type(JsonFieldType.STRING).description("배송 시작일"),
+                                fieldWithPath("content[].nextDeliveryDate").type(JsonFieldType.STRING).optional().description("다음 배송일"),
+                                fieldWithPath("content[].deliveryEndDate").type(JsonFieldType.STRING).description("배송 종료일"),
+                                fieldWithPath("content[].totalDeliveryCount").type(JsonFieldType.NUMBER).description("총 배송 횟수"),
+                                fieldWithPath("content[].remainingDeliveryCount").type(JsonFieldType.NUMBER).description("남은 배송 횟수"),
+                                fieldWithPath("content[].orderedProductList").type(JsonFieldType.ARRAY).description("주문된 상품 목록"),
+                                fieldWithPath("content[].orderedProductList[].productId").type(JsonFieldType.NUMBER).description("상품 ID"),
+                                fieldWithPath("content[].orderedProductList[].productName").type(JsonFieldType.STRING).description("상품 이름"),
+                                fieldWithPath("content[].orderedProductList[].count").type(JsonFieldType.NUMBER).description("상품 수량"),
+                                fieldWithPath("content[].orderedProductList[].price").type(JsonFieldType.NUMBER).description("상품 가격"),
+                                fieldWithPath("content[].orderedProductList[].discountRate").type(JsonFieldType.NUMBER).description("할인율"),
+                                fieldWithPath("content[].orderedProductList[].productImageList").type(JsonFieldType.ARRAY).optional().description("상품 이미지 목록"),
+                                fieldWithPath("content[].orderCreatedAt").type(JsonFieldType.STRING).description("주문 생성일"),
+                                fieldWithPath("content[].selectedDayList").type(JsonFieldType.ARRAY).description("선택된 요일 목록"),
+                                fieldWithPath("content[].selectedWeekOption").type(JsonFieldType.NUMBER).optional().description("선택된 주 옵션"),
+                                fieldWithPath("content[].selectedMonthOption").type(JsonFieldType.NUMBER).optional().description("선택된 월 옵션"),
+                                fieldWithPath("content[].couponEventId").type(JsonFieldType.NUMBER).optional().description("쿠폰이벤트 ID"),
+                                fieldWithPath("content[].couponName").type(JsonFieldType.STRING).optional().description("쿠폰 이름"),
+                                fieldWithPath("content[].couponDiscountRate").type(JsonFieldType.NUMBER).optional().description("쿠폰 할인율"),
+                                fieldWithPath("pageable").type(JsonFieldType.STRING).description("페이지 정보"),
+                                fieldWithPath("totalElements").type(JsonFieldType.NUMBER).description("총 주문 수"),
+                                fieldWithPath("totalPages").type(JsonFieldType.NUMBER).description("총 페이지 수"),
+                                fieldWithPath("last").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부"),
+                                fieldWithPath("size").type(JsonFieldType.NUMBER).description("페이지 크기"),
+                                fieldWithPath("number").type(JsonFieldType.NUMBER).description("현재 페이지 번호"),
+                                fieldWithPath("sort").type(JsonFieldType.OBJECT).description("정렬 정보"),
+                                fieldWithPath("sort.empty").type(JsonFieldType.BOOLEAN).description("정렬이 비어 있는지 여부"),
+                                fieldWithPath("sort.sorted").type(JsonFieldType.BOOLEAN).description("정렬되었는지 여부"),
+                                fieldWithPath("sort.unsorted").type(JsonFieldType.BOOLEAN).description("정렬되지 않았는지 여부"),
+                                fieldWithPath("numberOfElements").type(JsonFieldType.NUMBER).description("현재 페이지의 주문 수"),
+                                fieldWithPath("first").type(JsonFieldType.BOOLEAN).description("첫 페이지 여부"),
+                                fieldWithPath("empty").type(JsonFieldType.BOOLEAN).description("주문 목록이 비어있는지 여부")
+                        )
+                ));
+    }
+
+    @DisplayName("주문을 생성한다")
+    @Test
+    void order_Success() throws Exception {
+        // Given
+        Long customerId = 1L;
+        SaveOrderReq saveOrderReq = SaveOrderReq.builder()
+                .companyId(1L)
+                .addressId(1L)
+                .accountId(1L)
+                .eventId(1L)
+                .orderType(OrderType.ONETIME)
+                .deliveryStartDate(LocalDate.now().plusDays(3))
+                .orderedProducts(Collections.singletonList(
+                        FindOrderedProductSimpleReq.builder()
+                                .productId(1L)
+                                .count(2)
+                                .discountRate(10)
+                                .price(1000)
+                                .build()
+                ))
+                .build();
+
+        when(orderCreationService.createOrder(eq(customerId), any(SaveOrderReq.class))).thenReturn(1L);
+
+        // When & Then
+        mockMvc.perform(post("/orders/customers/{customerId}", customerId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(saveOrderReq)))
+                .andExpect(status().isOk())
+                .andExpect(content().string("success, 생성된 주문 아이디 : 1"))
+                .andDo(document("Order/create-order",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("customerId").description("고객 ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("companyId").type(JsonFieldType.NUMBER).description("회사 ID"),
+                                fieldWithPath("addressId").type(JsonFieldType.NUMBER).description("주소 ID"),
+                                fieldWithPath("accountId").type(JsonFieldType.NUMBER).description("계정 ID"),
+                                fieldWithPath("eventId").type(JsonFieldType.NUMBER).optional().description("쿠폰이벤트 ID"),
+                                fieldWithPath("monthOptionValue").type(JsonFieldType.NUMBER).optional().description("월 옵션 값"),
+                                fieldWithPath("weekOptionValue").type(JsonFieldType.NUMBER).optional().description("주 옵션 값"),
+                                fieldWithPath("orderType").type(JsonFieldType.STRING).description("주문 타입"),
+                                fieldWithPath("totalDeliveryCount").type(JsonFieldType.NUMBER).optional().description("총 배송 횟수"),
+                                fieldWithPath("deliveryStartDate").type(JsonFieldType.STRING).description("배송 시작일"),
+                                fieldWithPath("orderedProducts").type(JsonFieldType.ARRAY).description("주문 상품 목록"),
+                                fieldWithPath("orderedProducts[].productId").type(JsonFieldType.NUMBER).description("상품 ID"),
+                                fieldWithPath("orderedProducts[].count").type(JsonFieldType.NUMBER).description("상품 수량"),
+                                fieldWithPath("orderedProducts[].discountRate").type(JsonFieldType.NUMBER).description("할인율"),
+                                fieldWithPath("orderedProducts[].price").type(JsonFieldType.NUMBER).description("가격"),
+                                fieldWithPath("dayValueTypeList").type(JsonFieldType.ARRAY).optional().description("요일 옵션 목록")
+                        )
+                ));
+    }
+
+    @DisplayName("주문을 취소한다")
+    @Test
+    void cancelOrder_Success() throws Exception {
+        // Given
+        Long orderId = 1L;
+        CancelOrderReq cancelOrderReq = new CancelOrderReq();
+        ReflectionTestUtils.setField(cancelOrderReq, "customerId", 1L);
+        ReflectionTestUtils.setField(cancelOrderReq, "accountId", 1L);
+
+        doNothing().when(orderService).cancelOrder(eq(orderId), any(CancelOrderReq.class));
+
+        // When & Then
+        mockMvc.perform(post("/orders/{orderId}/cancel", orderId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(cancelOrderReq)))
+                .andExpect(status().isOk())
+                .andExpect(content().string("success"))
+                .andDo(document("Order/cancel-order",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("orderId").description("주문 ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("customerId").type(JsonFieldType.NUMBER).description("고객 ID"),
+                                fieldWithPath("accountId").type(JsonFieldType.NUMBER).description("계정 ID")
+                        )
+                ));
+    }
+
+    @DisplayName("주문을 승인한다")
+    @Test
+    void approveOrder_Success() throws Exception {
+        // Given
+        Long orderId = 1L;
+
+        doNothing().when(orderService).approveOrder(orderId);
+
+        // When & Then
+        mockMvc.perform(post("/orders/{orderId}/approve", orderId))
+                .andExpect(status().isOk())
+                .andExpect(content().string("success"))
+                .andDo(document("Order/approve-order",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("orderId").description("주문 ID")
+                        )
+                ));
+    }
+    @DisplayName("주문 자동 승인을 토글한다")
+    @Test
+    void toggleAutoApprove_Success() throws Exception {
+        // Given
+        Long companyId = 1L;
+
+        doNothing().when(orderService).toggleAutoApprove(companyId);
+
+        // When & Then
+        mockMvc.perform(post("/orders/auto-approve-toggle/company/{companyId}", companyId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().string("success"))
+                .andDo(document("Order/toggle-auto-approve",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("companyId").description("회사 ID")
+                        )
+                ));
+    }
+
+    @DisplayName("주문 ID로 주문을 조회한다")
+    @Test
+    void findOrderById_Success() throws Exception {
+        // Given
+        Long orderId = 1L;
+        FindOrderRes orderRes = FindOrderRes.builder()
+                .customer(FindCustomerSummaryRes.builder().id(1L).name("Test Customer").phoneNumber("010-1234-5678").build())
+                .orderId(1L)
+                .address(FindAddressSummaryRes.builder()
+                        .id(1L)
+                        .address("Test Address")
+                        .name("Test Name")
+                        .zipcode("12345")
+                        .addressDetail("Test Detail")
+                        .phoneNumber("010-1234-5678")
+                        .isDefaultAddress(DisplayStatus.Y)
+                        .addressName("Home")
+                        .createdAt(LocalDateTime.now())
+                        .build())
+                .orderCode("123456")
+                .type(OrderType.ONETIME)
+                .status(OrderStatus.APPROVED)
+                .deliveryStatus(DeliveryStatus.IN_PROGRESS)
+                .perPrice(20000)
+                .totalPrice(100000)
+                .deliveryStartDate(LocalDate.now())
+                .nextDeliveryDate(LocalDate.now().plusDays(1))
+                .deliveryEndDate(LocalDate.now().plusDays(7))
+                .totalDeliveryCount(1)
+                .remainingDeliveryCount(1)
+                .orderedProductList(Collections.singletonList(FindOrderedProductRes.builder()
+                        .productId(1L)
+                        .productName("Test Product")
+                        .count(2)
+                        .price(50000)
+                        .discountRate(10)
+                        .build()))
+                .orderCreatedAt(LocalDateTime.now())
+                .nextDeliveryDate(LocalDate.now().plusDays(1))
+                .build();
+
+        when(orderService.findOrder(orderId)).thenReturn(orderRes);
+
+        // When & Then
+        mockMvc.perform(get("/orders/{orderId}", orderId))
+                .andExpect(status().isOk())
+                .andDo(document("Order/find-order-by-id",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("orderId").description("주문 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("orderId").type(JsonFieldType.NUMBER).description("주문 ID"),
+                                fieldWithPath("customer").type(JsonFieldType.OBJECT).description("고객 정보"),
+                                fieldWithPath("customer.id").type(JsonFieldType.NUMBER).description("고객 ID"),
+                                fieldWithPath("customer.name").type(JsonFieldType.STRING).description("고객 이름"),
+                                fieldWithPath("customer.phoneNumber").type(JsonFieldType.STRING).description("고객 전화번호"),
+                                fieldWithPath("accountId").type(JsonFieldType.NUMBER).optional().description("계정 ID"),
+                                fieldWithPath("paymentCount").type(JsonFieldType.NUMBER).optional().description("결제 횟수"),
+                                fieldWithPath("nextPaymentDate").type(JsonFieldType.STRING).optional().description("다음 결제일"),
+                                fieldWithPath("thisMonthDeliveryCount").type(JsonFieldType.NUMBER).optional().description("이번 달 배송 횟수"),
+                                fieldWithPath("address").type(JsonFieldType.OBJECT).description("주소 정보"),
+                                fieldWithPath("address.id").type(JsonFieldType.NUMBER).description("주소 ID"),
+                                fieldWithPath("address.address").type(JsonFieldType.STRING).description("주소"),
+                                fieldWithPath("address.name").type(JsonFieldType.STRING).description("수령인 이름"),
+                                fieldWithPath("address.zipcode").type(JsonFieldType.STRING).description("우편번호"),
+                                fieldWithPath("address.addressDetail").type(JsonFieldType.STRING).description("상세 주소"),
+                                fieldWithPath("address.phoneNumber").type(JsonFieldType.STRING).description("전화번호"),
+                                fieldWithPath("address.isDefaultAddress").type(JsonFieldType.STRING).description("기본 주소 여부"),
+                                fieldWithPath("address.addressName").type(JsonFieldType.STRING).description("주소 별칭"),
+                                fieldWithPath("address.createdAt").type(JsonFieldType.STRING).description("주소 생성일"),
+                                fieldWithPath("orderCode").type(JsonFieldType.STRING).description("주문 코드"),
+                                fieldWithPath("type").type(JsonFieldType.STRING).description("주문 유형"),
+                                fieldWithPath("status").type(JsonFieldType.STRING).description("주문 상태"),
+                                fieldWithPath("deliveryStatus").type(JsonFieldType.STRING).description("배송 상태"),
+                                fieldWithPath("perPrice").type(JsonFieldType.NUMBER).description("1회 배송 가격"),
+                                fieldWithPath("totalPrice").type(JsonFieldType.NUMBER).description("총 가격"),
+                                fieldWithPath("deliveryStartDate").type(JsonFieldType.STRING).description("배송 시작일"),
+                                fieldWithPath("deliveryEndDate").type(JsonFieldType.STRING).description("배송 종료일"),
+                                fieldWithPath("nextDeliveryDate").type(JsonFieldType.STRING).description("다음 배송일"),
+                                fieldWithPath("totalDeliveryCount").type(JsonFieldType.NUMBER).description("총 배송 횟수"),
+                                fieldWithPath("remainingDeliveryCount").type(JsonFieldType.NUMBER).description("남은 배송 횟수"),
+                                fieldWithPath("orderedProductList").type(JsonFieldType.ARRAY).description("주문된 상품 목록"),
+                                fieldWithPath("orderedProductList[].productId").type(JsonFieldType.NUMBER).description("상품 ID"),
+                                fieldWithPath("orderedProductList[].productName").type(JsonFieldType.STRING).description("상품 이름"),
+                                fieldWithPath("orderedProductList[].count").type(JsonFieldType.NUMBER).description("상품 수량"),
+                                fieldWithPath("orderedProductList[].price").type(JsonFieldType.NUMBER).description("상품 가격"),
+                                fieldWithPath("orderedProductList[].discountRate").type(JsonFieldType.NUMBER).description("할인율"),
+                                fieldWithPath("orderedProductList[].productImageList").type(JsonFieldType.ARRAY).optional().description("상품 이미지 목록"),
+                                fieldWithPath("orderCreatedAt").type(JsonFieldType.STRING).description("주문 생성일"),
+                                fieldWithPath("selectedDayList").type(JsonFieldType.ARRAY).optional().description("선택된 배송 요일 목록"),
+                                fieldWithPath("selectedWeekOption").type(JsonFieldType.STRING).optional().description("선택된 주 옵션"),
+                                fieldWithPath("selectedMonthOption").type(JsonFieldType.STRING).optional().description("선택된 월 옵션"),
+                                fieldWithPath("couponEventId").type(JsonFieldType.NUMBER).optional().description("쿠폰이벤트 ID"),
+                                fieldWithPath("couponName").type(JsonFieldType.STRING).optional().description("쿠폰 이름"),
+                                fieldWithPath("couponDiscountRate").type(JsonFieldType.NUMBER).optional().description("쿠폰 할인율")
+                        )
+                ));
+    }
+
+    @DisplayName("주문 ID로 주문된 상품의 재고가 충분한지 확인한다")
+    @Test
+    void checkStock_Success() throws Exception {
+        // Given
+        Long orderId = 1L;
+        when(orderService.checkStock(orderId)).thenReturn(true);
+
+        // When & Then
+        mockMvc.perform(get("/orders/{orderId}/enough-stock", orderId))
+                .andExpect(status().isOk())
+                .andExpect(content().string("true"))
+                .andDo(document("Order/check-enough-stock",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("orderId").description("주문 ID")
+                        ),
+                        responseBody()
+                ));
+
+        // Additional test for false case
+        when(orderService.checkStock(orderId)).thenReturn(false);
+
+        mockMvc.perform(get("/orders/{orderId}/enough-stock", orderId))
+                .andExpect(status().isOk())
+                .andExpect(content().string("false"));
+    }
+
+
+}

--- a/backend/server/src/test/java/shop/sellution/server/payment/presentation/PaymentHistoryControllerTest.java
+++ b/backend/server/src/test/java/shop/sellution/server/payment/presentation/PaymentHistoryControllerTest.java
@@ -1,102 +1,187 @@
-//package shop.sellution.server.payment.presentation;
-//
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-//import org.springframework.boot.test.mock.mockito.MockBean;
-//import org.springframework.data.domain.Page;
-//import org.springframework.data.domain.PageImpl;
-//import org.springframework.data.domain.Pageable;
-//import org.springframework.http.MediaType;
-//import org.springframework.restdocs.payload.JsonFieldType;
-//import shop.sellution.server.common.BaseControllerTest;
-//import shop.sellution.server.payment.application.PaymentHistoryService;
-//import shop.sellution.server.payment.dto.request.FindPaymentHistoryCond;
-//import shop.sellution.server.payment.dto.response.FindPaymentHistoryRes;
-//
-//import java.time.LocalDateTime;
-//import java.util.Collections;
-//
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.ArgumentMatchers.eq;
-//import static org.mockito.Mockito.when;
-//import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-//import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-//import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
-//import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-//import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-//import static org.springframework.restdocs.request.RequestDocumentation.*;
-//import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-//
-//import shop.sellution.server.payment.domain.type.PaymentStatus;
-//
-//
-//@WebMvcTest(PaymentHistoryController.class)
-//class PaymentHistoryControllerTest extends BaseControllerTest {
-//
-//    @MockBean
-//    private PaymentHistoryService paymentHistoryService;
-//
-//
-//    @DisplayName("회사 ID로 결제 내역을 조회한다")
-//    @Test
-//    void findPaymentHistoryByCompanyId() throws Exception {
-//        // Given
-//        Long companyId = 1L;
-//        FindPaymentHistoryRes paymentHistoryRes = FindPaymentHistoryRes.builder()
-//                .paymentHisoryId(1L)
-//                .customerId(100L)
-//                .price(10000)
-//                .remainingPayCount(3)
-//                .totalCountForPayment(5)
-//                .paymentDate(LocalDateTime.now())
-//                .status(PaymentStatus.COMPLETE)
-//                .build();
-//        Page<FindPaymentHistoryRes> paymentHistoryPage = new PageImpl<>(Collections.singletonList(paymentHistoryRes));
-//
-//        when(paymentHistoryService.findPaymentHistoryByCompanyId(eq(companyId), any(FindPaymentHistoryCond.class), any(Pageable.class)))
-//                .thenReturn(paymentHistoryPage);
-//
-//        // When & Then
-//        mockMvc.perform(get("/payment-histories/company/{companyId}", companyId)
-//                        .param("page", "0")
-//                        .param("size", "10")
-//                        .contentType(MediaType.APPLICATION_JSON))
-//                .andExpect(status().isOk())
-//                .andDo(document("Payment/payment-history-list",
-//                        preprocessRequest(prettyPrint()),
-//                        preprocessResponse(prettyPrint()),
-//                        pathParameters(
-//                                parameterWithName("companyId").description("회사 ID")
-//                        ),
-//                        queryParameters(
-//                                parameterWithName("page").description("페이지 번호"),
-//                                parameterWithName("size").description("페이지 크기")
-//                        ),
-//                        responseFields(
-//                                fieldWithPath("content[]").type(JsonFieldType.ARRAY).description("결제 내역 목록"),
-//                                fieldWithPath("content[].paymentHisoryId").type(JsonFieldType.NUMBER).description("결제 내역 ID"),
-//                                fieldWithPath("content[].customerId").type(JsonFieldType.NUMBER).description("고객 ID"),
-//                                fieldWithPath("content[].price").type(JsonFieldType.NUMBER).description("결제 금액"),
-//                                fieldWithPath("content[].remainingPayCount").type(JsonFieldType.NUMBER).description("남은 결제 횟수"),
-//                                fieldWithPath("content[].totalCountForPayment").type(JsonFieldType.NUMBER).description("총 결제해야 하는 횟수"),
-//                                fieldWithPath("content[].paymentDate").type(JsonFieldType.STRING).description("결제 일시"),
-//                                fieldWithPath("content[].status").type(JsonFieldType.STRING).description("결제 상태"),
-//                                fieldWithPath("pageable").type(JsonFieldType.STRING).description("페이지 정보"),
-//                                fieldWithPath("totalElements").type(JsonFieldType.NUMBER).description("총 결제 내역 수"),
-//                                fieldWithPath("totalPages").type(JsonFieldType.NUMBER).description("총 페이지 수"),
-//                                fieldWithPath("last").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부"),
-//                                fieldWithPath("size").type(JsonFieldType.NUMBER).description("페이지 크기"),
-//                                fieldWithPath("number").type(JsonFieldType.NUMBER).description("현재 페이지 번호"),
-//                                fieldWithPath("sort").type(JsonFieldType.OBJECT).description("정렬 정보"),
-//                                fieldWithPath("sort.empty").type(JsonFieldType.BOOLEAN).description("정렬이 비어 있는지 여부"),
-//                                fieldWithPath("sort.sorted").type(JsonFieldType.BOOLEAN).description("정렬되었는지 여부"),
-//                                fieldWithPath("sort.unsorted").type(JsonFieldType.BOOLEAN).description("정렬되지 않았는지 여부"),
-//                                fieldWithPath("numberOfElements").type(JsonFieldType.NUMBER).description("현재 페이지의 결제 내역 수"),
-//                                fieldWithPath("first").type(JsonFieldType.BOOLEAN).description("첫 페이지 여부"),
-//                                fieldWithPath("empty").type(JsonFieldType.BOOLEAN).description("결제 내역이 비어있는지 여부")
-//                        )
-//                ));
-//    }
-//}
+package shop.sellution.server.payment.presentation;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import shop.sellution.server.common.BaseControllerTest;
+import shop.sellution.server.order.domain.type.OrderType;
+import shop.sellution.server.payment.application.PaymentHistoryService;
+import shop.sellution.server.payment.dto.request.FindPaymentHistoryCond;
+import shop.sellution.server.payment.dto.response.FindPaymentHistoryDetailRes;
+import shop.sellution.server.payment.dto.response.FindPaymentHistoryRes;
+import shop.sellution.server.payment.domain.type.PaymentStatus;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PaymentHistoryController.class)
+class PaymentHistoryControllerTest extends BaseControllerTest {
+
+    @MockBean
+    private PaymentHistoryService paymentHistoryService;
+
+    @DisplayName("회사 ID로 결제 내역을 조회한다")
+    @Test
+    void findPaymentHistoryByCompanyId() throws Exception {
+        // Given
+        Long companyId = 1L;
+        FindPaymentHistoryRes paymentHistoryRes = FindPaymentHistoryRes.builder()
+                .paymentHistoryId(1L)
+                .customerId(100L)
+                .orderCode("ORDER123")
+                .userName("John Doe")
+                .price(10000)
+                .remainingPayCount(3)
+                .totalCountForPayment(5)
+                .paymentDate(LocalDateTime.now())
+                .status(PaymentStatus.COMPLETE)
+                .build();
+        Page<FindPaymentHistoryRes> paymentHistoryPage = new PageImpl<>(Collections.singletonList(paymentHistoryRes));
+
+        when(paymentHistoryService.findPaymentHistoryByCompanyId(eq(companyId), any(FindPaymentHistoryCond.class), any(Pageable.class)))
+                .thenReturn(paymentHistoryPage);
+
+        // When & Then
+        mockMvc.perform(get("/payment-histories/company/{companyId}", companyId)
+                        .param("page", "0")
+                        .param("size", "10")
+                        .param("orderCode", "ORDER123")
+                        .param("userName", "John")
+                        .param("startDate", "2023-01-01")
+                        .param("endDate", "2023-12-31")
+                        .param("status", "COMPLETE")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(document("Payment/payment-history-list",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("companyId").description("회사 ID")
+                        ),
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호"),
+                                parameterWithName("size").description("페이지 크기"),
+                                parameterWithName("orderCode").description("주문 코드").optional(),
+                                parameterWithName("userName").description("사용자 이름").optional(),
+                                parameterWithName("startDate").description("시작 날짜").optional(),
+                                parameterWithName("endDate").description("종료 날짜").optional(),
+                                parameterWithName("status").description("결제 상태").optional()
+                        ),
+                        responseFields(
+                                fieldWithPath("content[]").type(JsonFieldType.ARRAY).description("결제 내역 목록"),
+                                fieldWithPath("content[].paymentHistoryId").type(JsonFieldType.NUMBER).description("결제 내역 ID"),
+                                fieldWithPath("content[].customerId").type(JsonFieldType.NUMBER).description("고객 ID"),
+                                fieldWithPath("content[].orderCode").type(JsonFieldType.STRING).description("주문 코드"),
+                                fieldWithPath("content[].userName").type(JsonFieldType.STRING).description("사용자 이름"),
+                                fieldWithPath("content[].price").type(JsonFieldType.NUMBER).description("결제 금액"),
+                                fieldWithPath("content[].remainingPayCount").type(JsonFieldType.NUMBER).description("남은 결제 횟수"),
+                                fieldWithPath("content[].totalCountForPayment").type(JsonFieldType.NUMBER).description("총 결제해야 하는 횟수"),
+                                fieldWithPath("content[].paymentDate").type(JsonFieldType.STRING).description("결제 일시"),
+                                fieldWithPath("content[].status").type(JsonFieldType.STRING).description("결제 상태"),
+                                fieldWithPath("pageable").type(JsonFieldType.STRING).description("페이지 정보"),
+                                fieldWithPath("totalElements").type(JsonFieldType.NUMBER).description("총 결제 내역 수"),
+                                fieldWithPath("totalPages").type(JsonFieldType.NUMBER).description("총 페이지 수"),
+                                fieldWithPath("last").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부"),
+                                fieldWithPath("size").type(JsonFieldType.NUMBER).description("페이지 크기"),
+                                fieldWithPath("number").type(JsonFieldType.NUMBER).description("현재 페이지 번호"),
+                                fieldWithPath("sort").type(JsonFieldType.OBJECT).description("정렬 정보"),
+                                fieldWithPath("sort.empty").type(JsonFieldType.BOOLEAN).description("정렬이 비어 있는지 여부"),
+                                fieldWithPath("sort.sorted").type(JsonFieldType.BOOLEAN).description("정렬되었는지 여부"),
+                                fieldWithPath("sort.unsorted").type(JsonFieldType.BOOLEAN).description("정렬되지 않았는지 여부"),
+                                fieldWithPath("numberOfElements").type(JsonFieldType.NUMBER).description("현재 페이지의 결제 내역 수"),
+                                fieldWithPath("first").type(JsonFieldType.BOOLEAN).description("첫 페이지 여부"),
+                                fieldWithPath("empty").type(JsonFieldType.BOOLEAN).description("결제 내역이 비어있는지 여부")
+                        )
+                ));
+    }
+
+    @DisplayName("주문 ID로 결제 내역 상세를 조회한다")
+    @Test
+    void findPaymentHistoryByOrderId() throws Exception {
+        // Given
+        Long orderId = 1L;
+        FindPaymentHistoryDetailRes paymentHistoryDetailRes = FindPaymentHistoryDetailRes.builder()
+                .paymentHistoryId(1L)
+                .price(10000)
+                .remainingPayCount(3)
+                .totalCountForPayment(5)
+                .paymentDate(LocalDateTime.now())
+                .status(PaymentStatus.COMPLETE)
+                .accountNumber("1234-5678-9012-3456")
+                .orderType(OrderType.ONETIME)
+                .thisSubMonthStartDate(LocalDate.now())
+                .thisSubMonthEndDate(LocalDate.now().plusMonths(1))
+                .deliveryPerPrice(2000)
+                .thisMonthDeliveryCount(4)
+                .build();
+        Page<FindPaymentHistoryDetailRes> paymentHistoryDetailPage = new PageImpl<>(Collections.singletonList(paymentHistoryDetailRes));
+
+        when(paymentHistoryService.findPaymentHistoryByOrderId(eq(orderId), any(Pageable.class)))
+                .thenReturn(paymentHistoryDetailPage);
+
+        // When & Then
+        mockMvc.perform(get("/payment-histories/orders/{orderId}", orderId)
+                        .param("page", "0")
+                        .param("size", "10")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(document("Payment/payment-history-detail-list",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("orderId").description("주문 ID")
+                        ),
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호"),
+                                parameterWithName("size").description("페이지 크기")
+                        ),
+                        responseFields(
+                                fieldWithPath("content[]").type(JsonFieldType.ARRAY).description("결제 내역 상세 목록"),
+                                fieldWithPath("content[].paymentHistoryId").type(JsonFieldType.NUMBER).description("결제 내역 ID"),
+                                fieldWithPath("content[].price").type(JsonFieldType.NUMBER).description("결제 금액"),
+                                fieldWithPath("content[].remainingPayCount").type(JsonFieldType.NUMBER).description("남은 결제 횟수"),
+                                fieldWithPath("content[].totalCountForPayment").type(JsonFieldType.NUMBER).description("총 결제해야 하는 횟수"),
+                                fieldWithPath("content[].paymentDate").type(JsonFieldType.STRING).description("결제 일시"),
+                                fieldWithPath("content[].status").type(JsonFieldType.STRING).description("결제 상태"),
+                                fieldWithPath("content[].accountNumber").type(JsonFieldType.STRING).description("계좌 번호"),
+                                fieldWithPath("content[].orderType").type(JsonFieldType.STRING).description("주문 타입"),
+                                fieldWithPath("content[].thisSubMonthStartDate").type(JsonFieldType.STRING).description("이번 구독 월 시작일"),
+                                fieldWithPath("content[].thisSubMonthEndDate").type(JsonFieldType.STRING).description("이번 구독 월 종료일"),
+                                fieldWithPath("content[].deliveryPerPrice").type(JsonFieldType.NUMBER).description("배송당 가격"),
+                                fieldWithPath("content[].thisMonthDeliveryCount").type(JsonFieldType.NUMBER).description("이번 달 배송 횟수"),
+                                fieldWithPath("pageable").type(JsonFieldType.STRING).description("페이지 정보"),
+                                fieldWithPath("totalElements").type(JsonFieldType.NUMBER).description("총 결제 내역 상세 수"),
+                                fieldWithPath("totalPages").type(JsonFieldType.NUMBER).description("총 페이지 수"),
+                                fieldWithPath("last").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부"),
+                                fieldWithPath("size").type(JsonFieldType.NUMBER).description("페이지 크기"),
+                                fieldWithPath("number").type(JsonFieldType.NUMBER).description("현재 페이지 번호"),
+                                fieldWithPath("sort").type(JsonFieldType.OBJECT).description("정렬 정보"),
+                                fieldWithPath("sort.empty").type(JsonFieldType.BOOLEAN).description("정렬이 비어 있는지 여부"),
+                                fieldWithPath("sort.sorted").type(JsonFieldType.BOOLEAN).description("정렬되었는지 여부"),
+                                fieldWithPath("sort.unsorted").type(JsonFieldType.BOOLEAN).description("정렬되지 않았는지 여부"),
+                                fieldWithPath("numberOfElements").type(JsonFieldType.NUMBER).description("현재 페이지의 결제 내역 상세 수"),
+                                fieldWithPath("first").type(JsonFieldType.BOOLEAN).description("첫 페이지 여부"),
+                                fieldWithPath("empty").type(JsonFieldType.BOOLEAN).description("결제 내역 상세가 비어있는지 여부")
+                        )
+                ));
+    }
+}

--- a/frontend/sellution-app/src/client/business/shopManagement/useShopManagementDisplaySetting.js
+++ b/frontend/sellution-app/src/client/business/shopManagement/useShopManagementDisplaySetting.js
@@ -49,7 +49,8 @@ export const useShopManagementDisplaySetting = ({
   const convertImageUrlToFileAndBlob = useCallback(async (imageUrl) => {
     try {
       // S3 버킷 URL을 프록시 URL로 변경
-      const proxyUrl = `/s3-bucket${imageUrl}`;
+      // const proxyUrl = `/s3-bucket${imageUrl}`;
+      const proxyUrl = `${imageUrl}`;
       const response = await fetch(proxyUrl);
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);


### PR DESCRIPTION
## :: 작업 내용
- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
- [ ] 테스트

## :: 구현 목표
 - 주문취소시 쿠폰 미사용상태로 변경, 
 - 배송시점에 재고없을시 주문취소, 
 - 간편비밀번호 암호화처리, 
 - 해당주문 재고파악 API추가